### PR TITLE
Add error page for PINNotSet-errors

### DIFF
--- a/credentialsd-common/src/model.rs
+++ b/credentialsd-common/src/model.rs
@@ -260,6 +260,8 @@ pub enum Error {
     /// Note that this is different than exhausting the PIN count that fully
     /// locks out the device.
     PinAttemptsExhausted,
+    /// The RP requires user verification, but the device has no PIN/Biometrics set.
+    PinNotSet,
     // TODO: We may want to hide the details on this variant from the public API.
     /// Something went wrong with the credential service itself, not the authenticator.
     Internal(String),
@@ -271,6 +273,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::AuthenticatorError => f.write_str("AuthenticatorError"),
+            Self::PinNotSet => f.write_str("PinNotSet"),
             Self::NoCredentials => f.write_str("NoCredentials"),
             Self::CredentialExcluded => f.write_str("CredentialExcluded"),
             Self::PinAttemptsExhausted => f.write_str("PinAttemptsExhausted"),

--- a/credentialsd-common/src/server.rs
+++ b/credentialsd-common/src/server.rs
@@ -219,6 +219,7 @@ impl TryFrom<&Value<'_>> for crate::model::Error {
         let err_code: &str = value.downcast_ref()?;
         let err = match err_code {
             "AuthenticatorError" => crate::model::Error::AuthenticatorError,
+            "PinNotSet" => crate::model::Error::PinNotSet,
             "NoCredentials" => crate::model::Error::NoCredentials,
             "CredentialExcluded" => crate::model::Error::CredentialExcluded,
             "PinAttemptsExhausted" => crate::model::Error::PinAttemptsExhausted,
@@ -436,6 +437,7 @@ impl TryFrom<&Structure<'_>> for crate::model::UsbState {
                 let err_code: &str = value.downcast_ref()?;
                 let err = match err_code {
                     "AuthenticatorError" => crate::model::Error::AuthenticatorError,
+                    "PinNotSet" => crate::model::Error::PinNotSet,
                     "NoCredentials" => crate::model::Error::NoCredentials,
                     "CredentialExcluded" => crate::model::Error::CredentialExcluded,
                     "PinAttemptsExhausted" => crate::model::Error::PinAttemptsExhausted,
@@ -558,6 +560,7 @@ impl TryFrom<&Structure<'_>> for crate::model::NfcState {
                 let err_code: &str = value.downcast_ref()?;
                 let err = match err_code {
                     "AuthenticatorError" => crate::model::Error::AuthenticatorError,
+                    "PinNotSet" => crate::model::Error::PinNotSet,
                     "NoCredentials" => crate::model::Error::NoCredentials,
                     "CredentialExcluded" => crate::model::Error::CredentialExcluded,
                     "PinAttemptsExhausted" => crate::model::Error::PinAttemptsExhausted,

--- a/credentialsd-ui/po/credentialsd-ui.pot
+++ b/credentialsd-ui/po/credentialsd-ui.pot
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: credentialsd-ui\n"
 "Report-Msgid-Bugs-To: \"https://github.com/linux-credentials/credentialsd/"
 "issues\"\n"
-"POT-Creation-Date: 2025-11-28 12:53-0600\n"
+"POT-Creation-Date: 2026-02-03 10:40+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 
 #: data/xyz.iinuwa.credentialsd.CredentialsUi.desktop.in.in:2
 #: data/xyz.iinuwa.credentialsd.CredentialsUi.metainfo.xml.in.in:8
-#: src/gui/view_model/gtk/mod.rs:380
+#: src/gui/view_model/gtk/mod.rs:385
 msgid "Credential Manager"
 msgstr ""
 
@@ -58,7 +58,6 @@ msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: data/xyz.iinuwa.credentialsd.CredentialsUi.metainfo.xml.in.in:34
-#: data/xyz.iinuwa.credentialsd.CredentialsUi.metainfo.xml.in.in:37
 msgid "Isaiah Inuwa"
 msgstr ""
 
@@ -97,72 +96,75 @@ msgstr ""
 msgid "Connect a security key"
 msgstr ""
 
-#: data/resources/ui/window.ui:138
+#: data/resources/ui/window.ui:139
 msgid "Scan the QR code to connect your device"
 msgstr ""
 
-#: data/resources/ui/window.ui:183 data/resources/ui/window.ui:189
+#: data/resources/ui/window.ui:184 data/resources/ui/window.ui:190
 msgid "Choose credential"
 msgstr ""
 
-#: data/resources/ui/window.ui:212
+#: data/resources/ui/window.ui:214
 msgid "Complete"
 msgstr ""
 
-#: data/resources/ui/window.ui:218
+#: data/resources/ui/window.ui:220
 msgid "Done!"
 msgstr ""
 
-#: data/resources/ui/window.ui:229
+#: data/resources/ui/window.ui:231
 msgid "Something went wrong."
 msgstr ""
 
-#: data/resources/ui/window.ui:242 src/gui/view_model/mod.rs:244
+#: data/resources/ui/window.ui:244 src/gui/view_model/mod.rs:290
 msgid ""
 "Something went wrong while retrieving a credential. Please try again later "
 "or use a different authenticator."
 msgstr ""
 
-#: src/gui/view_model/gtk/mod.rs:146
+#: src/gui/view_model/gtk/mod.rs:147
 msgid "Enter your PIN. One attempt remaining."
 msgid_plural "Enter your PIN. %d attempts remaining."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/gui/view_model/gtk/mod.rs:152
+#: src/gui/view_model/gtk/mod.rs:153
 msgid "Enter your PIN."
 msgstr ""
 
-#: src/gui/view_model/gtk/mod.rs:162
+#: src/gui/view_model/gtk/mod.rs:163
 msgid "Touch your device again. One attempt remaining."
 msgid_plural "Touch your device again. %d attempts remaining."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/gui/view_model/gtk/mod.rs:168
-#: src/gui/view_model/gtk/mod.rs:173
+#: src/gui/view_model/gtk/mod.rs:169
+msgid "Touch your device."
+msgstr ""
+
+#: src/gui/view_model/gtk/mod.rs:174
 msgid "Touch your device"
 msgstr ""
 
-#: src/gui/view_model/gtk/mod.rs:176
+#: src/gui/view_model/gtk/mod.rs:177
 msgid "Scan the QR code with your device to begin authentication."
 msgstr ""
 
-#: src/gui/view_model/gtk/mod.rs:186
+#: src/gui/view_model/gtk/mod.rs:187
 msgid ""
 "Connecting to your device. Make sure both devices are near each other and "
 "have Bluetooth enabled."
 msgstr ""
 
-#: src/gui/view_model/gtk/mod.rs:194
+#: src/gui/view_model/gtk/mod.rs:195
 msgid "Device connected. Follow the instructions on your device"
 msgstr ""
 
-#: src/gui/view_model/gtk/mod.rs:320
+#: src/gui/view_model/gtk/mod.rs:321
 msgid "Insert your security key."
 msgstr ""
 
-#: src/gui/view_model/gtk/mod.rs:339
+#: src/gui/view_model/gtk/mod.rs:340
 msgid "Multiple devices found. Please select with which to proceed."
 msgstr ""
 
@@ -211,7 +213,7 @@ msgstr ""
 #: src/gui/view_model/mod.rs:96
 msgid ""
 "<b>\"%s2\"</b> (process ID: %i1, binary: %s3) is asking to create a "
-"credential to sign in to \"%s1\". Only proceed if you trust this process."
+"credential to register at \"%s1\". Only proceed if you trust this process."
 msgstr ""
 
 #. TRANSLATORS: %s1 is the "relying party" (think: domain name) where the request is coming from
@@ -224,26 +226,30 @@ msgid ""
 "to sign in to \"%s1\". Only proceed if you trust this process."
 msgstr ""
 
-#: src/gui/view_model/mod.rs:224
+#: src/gui/view_model/mod.rs:227
 msgid "Failed to select credential from device."
 msgstr ""
 
 #: src/gui/view_model/mod.rs:281
-#: src/gui/view_model/mod.rs:332
 msgid "No matching credentials found on this authenticator."
 msgstr ""
 
 #: src/gui/view_model/mod.rs:284
-#: src/gui/view_model/mod.rs:335
 msgid ""
 "No more PIN attempts allowed. Try removing your device and plugging it back "
 "in."
 msgstr ""
 
-#: src/gui/view_model/mod.rs:290
+#: src/gui/view_model/mod.rs:287
+msgid ""
+"This server requires your device to have additional protection like a PIN, "
+"which is not set. Please set a PIN for this device and try again."
+msgstr ""
+
+#: src/gui/view_model/mod.rs:293
 msgid "This credential is already registered on this authenticator."
 msgstr ""
 
-#: src/gui/view_model/mod.rs:389
+#: src/gui/view_model/mod.rs:395
 msgid "Something went wrong. Try again later or use a different authenticator."
 msgstr ""

--- a/credentialsd-ui/po/de_DE.po
+++ b/credentialsd-ui/po/de_DE.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \"https://github.com/linux-credentials/credentialsd/"
 "issues\"\n"
-"POT-Creation-Date: 2025-10-30 14:43+0100\n"
+"POT-Creation-Date: 2026-02-03 10:40+0100\n"
 "PO-Revision-Date: 2025-10-10 14:45+0200\n"
 "Last-Translator: Martin Sirringhaus <martin.sirringhaus@suse.com>\n"
 "Language: de_DE\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/xyz.iinuwa.credentialsd.CredentialsUi.desktop.in.in:2
 #: data/xyz.iinuwa.credentialsd.CredentialsUi.metainfo.xml.in.in:8
-#: src/gui/view_model/gtk/mod.rs:378
+#: src/gui/view_model/gtk/mod.rs:385
 msgid "Credential Manager"
 msgstr "Zugangsdatenmanager"
 
@@ -81,30 +81,30 @@ msgid "Devices"
 msgstr "Geräte"
 
 #: data/resources/ui/window.ui:98
-msgid "Plug in security key"
-msgstr "Stecken Sie Ihren Security-Token ein"
+msgid "Connect a security key"
+msgstr "Stecken Sie Ihren Security-Token ein."
 
-#: data/resources/ui/window.ui:138
+#: data/resources/ui/window.ui:139
 msgid "Scan the QR code to connect your device"
 msgstr "Scannen Sie den QR-Code, um Ihr Gerät zu verbinden"
 
-#: data/resources/ui/window.ui:183 data/resources/ui/window.ui:189
+#: data/resources/ui/window.ui:184 data/resources/ui/window.ui:190
 msgid "Choose credential"
 msgstr "Wählen Sie Zugangsdaten aus"
 
-#: data/resources/ui/window.ui:212
+#: data/resources/ui/window.ui:214
 msgid "Complete"
 msgstr "Abgeschlossen"
 
-#: data/resources/ui/window.ui:218
+#: data/resources/ui/window.ui:220
 msgid "Done!"
 msgstr "Fertig!"
 
-#: data/resources/ui/window.ui:229
+#: data/resources/ui/window.ui:231
 msgid "Something went wrong."
 msgstr "Etwas ist schief gegangen."
 
-#: data/resources/ui/window.ui:242 src/gui/view_model/mod.rs:280
+#: data/resources/ui/window.ui:244 src/gui/view_model/mod.rs:290
 msgid ""
 "Something went wrong while retrieving a credential. Please try again later "
 "or use a different authenticator."
@@ -112,37 +112,37 @@ msgstr ""
 "Beim Abrufen Ihrer Zugangsdaten ist ein Fehler aufgetreten. Versuchen Sie es "
 "später wieder, oder verwenden Sie einen anderen Security-Token."
 
-#: src/gui/view_model/gtk/mod.rs:145
+#: src/gui/view_model/gtk/mod.rs:147
 #, fuzzy
 msgid "Enter your PIN. One attempt remaining."
 msgid_plural "Enter your PIN. %d attempts remaining."
 msgstr[0] "Geben Sie Ihren PIN ein. Sie haben nur noch einen Versuch."
 msgstr[1] "Geben Sie Ihren PIN ein. Sie haben noch %d Versuche."
 
-#: src/gui/view_model/gtk/mod.rs:151
+#: src/gui/view_model/gtk/mod.rs:153
 msgid "Enter your PIN."
 msgstr "Geben Sie Ihren PIN ein."
 
-#: src/gui/view_model/gtk/mod.rs:160
+#: src/gui/view_model/gtk/mod.rs:163
 msgid "Touch your device again. One attempt remaining."
 msgid_plural "Touch your device again. %d attempts remaining."
 msgstr[0] "Berühren Sie Ihr Gerät. Sie haben nur noch einen Versuch."
 msgstr[1] "Berühren Sie nochmal Ihr Gerät. Sie haben nur noch %d Versuche."
 
-#: src/gui/view_model/gtk/mod.rs:166
+#: src/gui/view_model/gtk/mod.rs:169
 msgid "Touch your device."
 msgstr "Berühren Sie Ihr Gerät."
 
-#: src/gui/view_model/gtk/mod.rs:171
+#: src/gui/view_model/gtk/mod.rs:174
 msgid "Touch your device"
 msgstr "Berühren Sie Ihr Gerät."
 
-#: src/gui/view_model/gtk/mod.rs:174
+#: src/gui/view_model/gtk/mod.rs:177
 msgid "Scan the QR code with your device to begin authentication."
 msgstr ""
 "Scannen Sie den QR code mit ihrem Gerät um die Authentifizierung zu beginnen."
 
-#: src/gui/view_model/gtk/mod.rs:184
+#: src/gui/view_model/gtk/mod.rs:187
 msgid ""
 "Connecting to your device. Make sure both devices are near each other and "
 "have Bluetooth enabled."
@@ -150,15 +150,15 @@ msgstr ""
 "Verbindung zu Ihrem Gerät wird aufgebaut. Stellen Sie sicher, dass beide "
 "Geräte nah beieinander sind und Bluetooth aktiviert haben."
 
-#: src/gui/view_model/gtk/mod.rs:192
+#: src/gui/view_model/gtk/mod.rs:195
 msgid "Device connected. Follow the instructions on your device"
 msgstr "Verbindung hergestellt. Folgen Sie den Anweisungen auf Ihrem Gerät."
 
-#: src/gui/view_model/gtk/mod.rs:318
+#: src/gui/view_model/gtk/mod.rs:321
 msgid "Insert your security key."
 msgstr "Stecken Sie Ihren Security-Token ein."
 
-#: src/gui/view_model/gtk/mod.rs:334
+#: src/gui/view_model/gtk/mod.rs:340
 msgid "Multiple devices found. Please select with which to proceed."
 msgstr "Mehrere Geräte gefunden. Bitte wählen Sie einen aus, um fortzufahren."
 
@@ -179,7 +179,7 @@ msgid "Linked Device"
 msgstr "Verbundenes Gerät"
 
 #: src/gui/view_model/gtk/device.rs:61
-msgid "A security key or card (NFC)"
+msgid "An security key or card (NFC)"
 msgstr "Ein NFC-Gerät"
 
 #: src/gui/view_model/gtk/device.rs:62
@@ -209,8 +209,9 @@ msgid ""
 "<b>\"%s2\"</b> (process ID: %i1, binary: %s3) is asking to create a "
 "credential to register at \"%s1\". Only proceed if you trust this process."
 msgstr ""
-"<b>\"%s2\"</b> (Prozess-ID: %i1, ausführbare Datei: %s3) möchte neue Zugangsdaten erstellen, "
-"um Sie bei \"%s1\" zu registrieren. Fahren Sie nur fort, wenn Sie diesem Prozess vertrauen."
+"<b>\"%s2\"</b> (Prozess-ID: %i1, ausführbare Datei: %s3) möchte neue "
+"Zugangsdaten erstellen, um Sie bei \"%s1\" zu registrieren. Fahren Sie nur "
+"fort, wenn Sie diesem Prozess vertrauen."
 
 #. TRANSLATORS: %s1 is the "relying party" (think: domain name) where the request is coming from
 #. TRANSLATORS: %s2 is the application name (e.g.: firefox) where the request is coming from, <b></b> must be left untouched to make the name bold
@@ -221,18 +222,19 @@ msgid ""
 "<b>\"%s2\"</b> (process ID: %i1, binary: %s3) is asking to use a credential "
 "to sign in to \"%s1\". Only proceed if you trust this process."
 msgstr ""
-"<b>\"%s2\"</b> (Prozess-ID: %i1, ausführbare Datei: %s3) möchte Zugangsdaten abrufen, um "
-"Sie bei \"%s1\" anzumelden. Fahren Sie nur fort, wenn Sie diesem Prozess vertrauen."
+"<b>\"%s2\"</b> (Prozess-ID: %i1, ausführbare Datei: %s3) möchte Zugangsdaten "
+"abrufen, um Sie bei \"%s1\" anzumelden. Fahren Sie nur fort, wenn Sie diesem "
+"Prozess vertrauen."
 
-#: src/gui/view_model/mod.rs:220
+#: src/gui/view_model/mod.rs:227
 msgid "Failed to select credential from device."
 msgstr "Zugangsdaten vom Gerät konnten nicht ausgewählt werden."
 
-#: src/gui/view_model/mod.rs:274
+#: src/gui/view_model/mod.rs:281
 msgid "No matching credentials found on this authenticator."
 msgstr "Keine passenden Zugangsdaten auf diesem Gerät gefunden."
 
-#: src/gui/view_model/mod.rs:277
+#: src/gui/view_model/mod.rs:284
 msgid ""
 "No more PIN attempts allowed. Try removing your device and plugging it back "
 "in."
@@ -240,11 +242,19 @@ msgstr ""
 "Keine weiteren PIN-Eingaben erlaubt. Versuchen Sie ihr Gerät aus- und wieder "
 "einzustecken."
 
-#: src/gui/view_model/mod.rs:283
+#: src/gui/view_model/mod.rs:287
+msgid ""
+"This server requires your device to have additional protection like a PIN, "
+"which is not set. Please set a PIN for this device and try again."
+msgstr ""
+"Für diesen Server benötigt ihr Gerät eine zusätzliche Absicherung, z.B. einen PIN. "
+"Bitte setzen Sie einen PIN für ihr Gerät und versuchen Sie es erneut."
+
+#: src/gui/view_model/mod.rs:293
 msgid "This credential is already registered on this authenticator."
 msgstr "Diese Zugangsdaten sind bereits auf diesem Gerät registriert."
 
-#: src/gui/view_model/mod.rs:331
+#: src/gui/view_model/mod.rs:395
 msgid "Something went wrong. Try again later or use a different authenticator."
 msgstr ""
 "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal, "

--- a/credentialsd-ui/po/en_US.po
+++ b/credentialsd-ui/po/en_US.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \"https://github.com/linux-credentials/credentialsd/"
 "issues\"\n"
-"POT-Creation-Date: 2025-10-30 14:43+0100\n"
+"POT-Creation-Date: 2026-02-03 10:40+0100\n"
 "PO-Revision-Date: 2025-10-10 14:45+0200\n"
 "Last-Translator: Martin Sirringhaus <martin.sirringhaus@suse.com>\n"
 "Language: en_US\n"
@@ -13,7 +13,7 @@ msgstr ""
 
 #: data/xyz.iinuwa.credentialsd.CredentialsUi.desktop.in.in:2
 #: data/xyz.iinuwa.credentialsd.CredentialsUi.metainfo.xml.in.in:8
-#: src/gui/view_model/gtk/mod.rs:378
+#: src/gui/view_model/gtk/mod.rs:385
 msgid "Credential Manager"
 msgstr "Credential Manager"
 
@@ -85,27 +85,27 @@ msgstr "Devices"
 msgid "Connect a security key"
 msgstr "Connect a security key"
 
-#: data/resources/ui/window.ui:138
+#: data/resources/ui/window.ui:139
 msgid "Scan the QR code to connect your device"
 msgstr "Scan the QR code to connect your device"
 
-#: data/resources/ui/window.ui:183 data/resources/ui/window.ui:189
+#: data/resources/ui/window.ui:184 data/resources/ui/window.ui:190
 msgid "Choose credential"
 msgstr "Choose credential"
 
-#: data/resources/ui/window.ui:212
+#: data/resources/ui/window.ui:214
 msgid "Complete"
 msgstr "Complete"
 
-#: data/resources/ui/window.ui:218
+#: data/resources/ui/window.ui:220
 msgid "Done!"
 msgstr "Done!"
 
-#: data/resources/ui/window.ui:229
+#: data/resources/ui/window.ui:231
 msgid "Something went wrong."
 msgstr "Something went wrong."
 
-#: data/resources/ui/window.ui:242 src/gui/view_model/mod.rs:280
+#: data/resources/ui/window.ui:244 src/gui/view_model/mod.rs:290
 msgid ""
 "Something went wrong while retrieving a credential. Please try again later "
 "or use a different authenticator."
@@ -113,36 +113,35 @@ msgstr ""
 "Something went wrong while retrieving a credential. Please try again later "
 "or use a different authenticator."
 
-#: src/gui/view_model/gtk/mod.rs:145
-#, fuzzy
+#: src/gui/view_model/gtk/mod.rs:147
 msgid "Enter your PIN. One attempt remaining."
 msgid_plural "Enter your PIN. %d attempts remaining."
 msgstr[0] "Enter your PIN. One attempt remaining."
 msgstr[1] "Enter your PIN. %d attempts remaining."
 
-#: src/gui/view_model/gtk/mod.rs:151
+#: src/gui/view_model/gtk/mod.rs:153
 msgid "Enter your PIN."
 msgstr "Enter your PIN."
 
-#: src/gui/view_model/gtk/mod.rs:160
+#: src/gui/view_model/gtk/mod.rs:163
 msgid "Touch your device again. One attempt remaining."
 msgid_plural "Touch your device again. %d attempts remaining."
 msgstr[0] "Touch your device again. One attempt remaining."
 msgstr[1] "Touch your device again. %d attempts remaining."
 
-#: src/gui/view_model/gtk/mod.rs:166
+#: src/gui/view_model/gtk/mod.rs:169
 msgid "Touch your device."
 msgstr "Touch your device."
 
-#: src/gui/view_model/gtk/mod.rs:171
+#: src/gui/view_model/gtk/mod.rs:174
 msgid "Touch your device"
 msgstr "Touch your device"
 
-#: src/gui/view_model/gtk/mod.rs:174
+#: src/gui/view_model/gtk/mod.rs:177
 msgid "Scan the QR code with your device to begin authentication."
 msgstr "Scan the QR code with your device to begin authentication."
 
-#: src/gui/view_model/gtk/mod.rs:184
+#: src/gui/view_model/gtk/mod.rs:187
 msgid ""
 "Connecting to your device. Make sure both devices are near each other and "
 "have Bluetooth enabled."
@@ -150,15 +149,15 @@ msgstr ""
 "Connecting to your device. Make sure both devices are near each other and "
 "have Bluetooth enabled."
 
-#: src/gui/view_model/gtk/mod.rs:192
+#: src/gui/view_model/gtk/mod.rs:195
 msgid "Device connected. Follow the instructions on your device"
 msgstr "Device connected. Follow the instructions on your device"
 
-#: src/gui/view_model/gtk/mod.rs:318
+#: src/gui/view_model/gtk/mod.rs:321
 msgid "Insert your security key."
 msgstr "Insert your security key."
 
-#: src/gui/view_model/gtk/mod.rs:334
+#: src/gui/view_model/gtk/mod.rs:340
 msgid "Multiple devices found. Please select with which to proceed."
 msgstr "Multiple devices found. Please select with which to proceed."
 
@@ -179,7 +178,7 @@ msgid "Linked Device"
 msgstr "Linked Device"
 
 #: src/gui/view_model/gtk/device.rs:61
-msgid "A security key or card (NFC)"
+msgid "An security key or card (NFC)"
 msgstr "A security key or card (NFC)"
 
 #: src/gui/view_model/gtk/device.rs:62
@@ -224,15 +223,15 @@ msgstr ""
 "<b>\"%s2\"</b> (process ID: %i1, binary: %s3) is asking to use a credential "
 "to sign in to \"%s1\". Only proceed if you trust this process."
 
-#: src/gui/view_model/mod.rs:220
+#: src/gui/view_model/mod.rs:227
 msgid "Failed to select credential from device."
 msgstr "Failed to select credential from device."
 
-#: src/gui/view_model/mod.rs:274
+#: src/gui/view_model/mod.rs:281
 msgid "No matching credentials found on this authenticator."
 msgstr "No matching credentials found on this authenticator."
 
-#: src/gui/view_model/mod.rs:277
+#: src/gui/view_model/mod.rs:284
 msgid ""
 "No more PIN attempts allowed. Try removing your device and plugging it back "
 "in."
@@ -240,11 +239,19 @@ msgstr ""
 "No more PIN attempts allowed. Try removing your device and plugging it back "
 "in."
 
-#: src/gui/view_model/mod.rs:283
+#: src/gui/view_model/mod.rs:287
+msgid ""
+"This server requires your device to have additional protection like a PIN, "
+"which is not set. Please set a PIN for this device and try again."
+msgstr ""
+"This server requires your device to have additional protection like a PIN, "
+"which is not set. Please set a PIN for this device and try again."
+
+#: src/gui/view_model/mod.rs:293
 msgid "This credential is already registered on this authenticator."
 msgstr "This credential is already registered on this authenticator."
 
-#: src/gui/view_model/mod.rs:331
+#: src/gui/view_model/mod.rs:395
 msgid "Something went wrong. Try again later or use a different authenticator."
 msgstr ""
 "Something went wrong. Try again later or use a different authenticator."

--- a/credentialsd-ui/src/gui/view_model/mod.rs
+++ b/credentialsd-ui/src/gui/view_model/mod.rs
@@ -283,6 +283,9 @@ impl<F: FlowController + Send> ViewModel<F> {
                                 Error::PinAttemptsExhausted => gettext(
                                     "No more PIN attempts allowed. Try removing your device and plugging it back in.",
                                 ),
+                                Error::PinNotSet => gettext(
+                                    "This server requires your device to have additional protection like a PIN, which is not set. Please set a PIN for this device and try again.",
+                                ),
                                 Error::AuthenticatorError | Error::Internal(_) => gettext(
                                     "Something went wrong while retrieving a credential. Please try again later or use a different authenticator.",
                                 ),
@@ -333,6 +336,9 @@ impl<F: FlowController + Send> ViewModel<F> {
                                 }
                                 Error::PinAttemptsExhausted => {
                                     "No more PIN attempts allowed. Try removing your device and plugging it back in."
+                                }
+                                Error::PinNotSet => {
+                                    "This server requires your device to have additional protection like a PIN, which is not set. Please set a PIN for this device and try again."
                                 }
                                 Error::AuthenticatorError | Error::Internal(_) => {
                                     "Something went wrong while retrieving a credential. Please try again later or use a different authenticator."

--- a/credentialsd/src/credential_service/nfc.rs
+++ b/credentialsd/src/credential_service/nfc.rs
@@ -252,6 +252,7 @@ async fn handle_events(
             }
             .map_err(|err| match err {
                 WebAuthnError::Ctap(CtapError::PINAuthBlocked) => Error::PinAttemptsExhausted,
+                WebAuthnError::Ctap(CtapError::PINNotSet) => Error::PinNotSet,
                 WebAuthnError::Ctap(CtapError::NoCredentials) => Error::NoCredentials,
                 WebAuthnError::Ctap(CtapError::CredentialExcluded) => Error::CredentialExcluded,
                 _ => Error::AuthenticatorError,

--- a/credentialsd/src/credential_service/usb.rs
+++ b/credentialsd/src/credential_service/usb.rs
@@ -342,6 +342,7 @@ async fn handle_events(
             }
             .map_err(|err| match err {
                 WebAuthnError::Ctap(CtapError::PINAuthBlocked) => Error::PinAttemptsExhausted,
+                WebAuthnError::Ctap(CtapError::PINNotSet) => Error::PinNotSet,
                 WebAuthnError::Ctap(CtapError::NoCredentials) => Error::NoCredentials,
                 WebAuthnError::Ctap(CtapError::CredentialExcluded) => Error::CredentialExcluded,
                 _ => Error::AuthenticatorError,


### PR DESCRIPTION
Also, I adjusted the binary path in BUILDING.md which I think is no longer correct.

Note: This is a stop gap measure to at least get a sensible error message. I want to supersede this soon ( :tm: ) with a proper dialog for actually setting the PIN.