### PR TITLE
daemon: Use string instead of PathBuf for app path

### DIFF
--- a/credentialsd-common/src/model.rs
+++ b/credentialsd-common/src/model.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, path::PathBuf};
+use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 use zvariant::{SerializeDict, Type};
@@ -99,7 +99,7 @@ impl Transport {
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Type)]
 pub struct RequestingApplication {
     pub name: String,
-    pub path: PathBuf,
+    pub path: String,
     pub pid: u32,
 }
 

--- a/credentialsd-ui/src/gui/view_model/mod.rs
+++ b/credentialsd-ui/src/gui/view_model/mod.rs
@@ -107,7 +107,7 @@ impl<F: FlowController + Send> ViewModel<F> {
         subtitle = subtitle.replace("%s1", &self.rp_id);
         subtitle = subtitle.replace("%i1", &format!("{}", requesting_app.pid));
         subtitle = subtitle.replace("%s2", &requesting_app.name);
-        subtitle = subtitle.replace("%s3", &requesting_app.path.to_string_lossy());
+        subtitle = subtitle.replace("%s3", &requesting_app.path);
         self.title = title;
         self.subtitle = subtitle;
         self.tx_update

--- a/credentialsd/src/dbus/gateway.rs
+++ b/credentialsd/src/dbus/gateway.rs
@@ -208,7 +208,7 @@ async fn query_connection_peer_binary(
 
     Some(RequestingApplication {
         name: command_name,
-        path: exe_path,
+        path: exe_path.to_string_lossy().to_string(),
         pid,
     })
 }


### PR DESCRIPTION
This is in preparation for using an app ID as a substitute for the path for the portal API