### PR TITLE
ci: pin Rust toolchain, update actions, add audit and JS checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,9 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: rustup show active-toolchain
-      - run: rustup component add rustfmt clippy
 
       - name: Configure Rust cache
         uses: Swatinem/rust-cache@v2
@@ -64,3 +63,11 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --all --check
+
+      - name: Audit dependencies
+        run: |
+          cargo install cargo-audit --locked
+          cargo audit
+
+      - name: Validate web extension JS syntax
+        run: node --check webext/add-on/*.js

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Pin Rust toolchain to 1.85 via `rust-toolchain.toml` (MSRV for edition 2024 used by `credentialsd-common` and `credentialsd-ui`)
- Update `actions/checkout` from v2 to v4
- Remove manual `rustup component add rustfmt clippy` — now declared in `rust-toolchain.toml`
- Add `cargo audit` step for dependency vulnerability scanning
- Add `node --check` step to validate web extension JS syntax

## Test plan
- [ ] CI pipeline passes with updated actions and new checks
- [ ] `cargo audit` runs successfully
- [ ] `node --check` validates JS syntax in `webext/add-on/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)