### PR TITLE
chore(deps): bump libwebauthn to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "libwebauthn"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a559a67cfb294f94c6e20669493c246cbe4232d2facdb02bae6130721d322f3e"
+checksum = "8c49abf1fc00b4ef5f4324e8d868d35680a5aef3e56cc6402ad555236fff2ded"
 dependencies = [
  "aes",
  "apdu",

--- a/credentialsd/Cargo.toml
+++ b/credentialsd/Cargo.toml
@@ -12,7 +12,7 @@ base64 = "0.22.1"
 credentialsd-common = { path = "../credentialsd-common" }
 futures-lite.workspace = true
 libc.workspace = true
-libwebauthn = { version = "0.5.0", features = ["nfc-backend-libnfc", "nfc-backend-pcsc"] }
+libwebauthn = { version = "0.5.1", features = ["nfc-backend-libnfc", "nfc-backend-pcsc"] }
 # 0.6.1 fails to build with non-vendored library.
 # https://github.com/alexrsagen/rs-nfc1/issues/15
 nfc1 = { version = "=0.6.0", default-features = false }


### PR DESCRIPTION
Picks up the hybrid GetInfo timeout fix from libwebauthn 0.5.1 (regression introduced in 0.5.0 that made every hybrid attempt fail immediately with `Transport(Timeout)`).