### PR TITLE
ui: Consistently build Blueprint file

### DIFF
--- a/credentialsd-ui/data/resources/ui/meson.build
+++ b/credentialsd-ui/data/resources/ui/meson.build
@@ -3,12 +3,12 @@ blueprint_compiler = find_program('blueprint-compiler', version: '>= 0.20.4')
 blueprint_templates = custom_target(
   'blueprints',
   input: files('window.blp'),
-  output: '.',
+  output: 'window.ui',
   command: [
     blueprint_compiler,
-    'batch-compile',
-    '@OUTPUT@',
-    '@CURRENT_SOURCE_DIR@',
+    'compile',
+    '--minify',
+    '--output', '@OUTPUT@',
     '@INPUT@',
   ],
 )


### PR DESCRIPTION
Using batch-compile with the `.` arg as the output means that Meson cannot tell what files are generated by the command, causing you to have to run the build multiple times to get updates. Switching to explicitly declaring the output should fix this issue.