### PR TITLE
Move CARGO_HOME to take advantage of cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_HOME: build/cargo-home
   CARGO_TARGET_DIR: ${{ github.workspace }}/build/target
 
 jobs:
@@ -18,6 +17,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
+
+      # Set CARGO_HOME outside the workspace so that Swatinem/rust-cache (below)
+      # does not consider it workspace local and thus not a dependency to cache.
+      # runner.temp is not valid in 'env:' above, so have to set it here.
+      - name: Set CARGO_HOME
+        run: echo "CARGO_HOME=${{ runner.temp }}/cargo-home" >> "$GITHUB_ENV"
 
       - run: rustup show active-toolchain
       - run: rustup component add rustfmt clippy
@@ -72,7 +77,7 @@ jobs:
           echo ~/.local/bin >> $GITHUB_PATH
 
       - name: Setup meson project
-        run: meson setup -Dprofile=development -Dcargo_locked=true build
+        run: meson setup -Dprofile=development -Dcargo_locked=true -Dcargo_home="$CARGO_HOME" build
 
       - name: Build
         run: ninja -C build


### PR DESCRIPTION
`CARGO_HOME` is set to `build/cargo-home` which is inside the workspace. This folder contains the `.../registry/src` folders. Being inside the workspace makes `Swatinem/rust-cache` consider it local code and thus deletes the built dependencies at job end, regardless of location.

Move `CARGO_HOME` outside the workspace so the rust cache considers the build dependencies as non-local.

Helps with #95