### PR TITLE
build: Remove FlowControlService service activation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Reordered parameters in RequestingApplication, and made app name optional.
 
+### Flow Controller API
+
+- Removed FlowControl service.
+
+## Improvements
+
+- Added a handler service to handle Credential portal requests on behalf of xdg-desktop-portal.
+
 # [0.2.0] - 2025-02-18
 
 ## Breaking Changes

--- a/dbus/meson.build
+++ b/dbus/meson.build
@@ -12,12 +12,6 @@ configure_file(
   configuration: dbus_config,
 )
 configure_file(
-  input: 'xyz.iinuwa.credentialsd.FlowControl.service.in',
-  install_dir: dbus_service_dir,
-  output: 'xyz.iinuwa.credentialsd.FlowControl.service',
-  configuration: dbus_config,
-)
-configure_file(
   input: 'xyz.iinuwa.credentialsd.UiControl.service.in',
   install_dir: dbus_service_dir,
   output: 'xyz.iinuwa.credentialsd.UiControl.service',

--- a/dbus/xyz.iinuwa.credentialsd.FlowControl.service.in
+++ b/dbus/xyz.iinuwa.credentialsd.FlowControl.service.in
@@ -1,4 +1,0 @@
-[D-BUS Service]
-Name=xyz.iinuwa.credentialsd.FlowControl
-Exec=@DAEMON_EXECUTABLE@
-SystemdService=xyz.iinuwa.credentialsd.FlowControl.service

--- a/systemd/meson.build
+++ b/systemd/meson.build
@@ -14,12 +14,6 @@ configure_file(
   configuration: systemd_config,
 )
 configure_file(
-  input: 'xyz.iinuwa.credentialsd.FlowControl.service.in',
-  install_dir: systemd_user_service_dir,
-  output: 'xyz.iinuwa.credentialsd.FlowControl.service',
-  configuration: systemd_config,
-)
-configure_file(
   input: 'xyz.iinuwa.credentialsd.UiControl.service.in',
   install_dir: systemd_user_service_dir,
   output: 'xyz.iinuwa.credentialsd.UiControl.service',

--- a/systemd/xyz.iinuwa.credentialsd.FlowControl.service.in
+++ b/systemd/xyz.iinuwa.credentialsd.FlowControl.service.in
@@ -1,7 +1,0 @@
-[Unit]
-Description=Internal helper service for credentialsd
-
-[Service]
-Type=dbus
-BusName=xyz.iinuwa.credentialsd.FlowControl
-ExecStart=@DAEMON_EXECUTABLE@


### PR DESCRIPTION
We removed the FlowControlService a while ago, but didn't clean up the service activation files.