### PR TITLE
daemon: Fail discovery when all transports exit silently

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,7 +125,8 @@ USB, hybrid, and NFC handler events pass through shared request lifecycle
 handling, while each transport keeps its own public states. All selected
 transports share one snapshot of their originating request. Terminal events
 are scoped to that request, so stale streams cannot complete a newer request.
-Cancellation wakes pending streams.
+Cancellation wakes pending streams. If every selected transport ends without
+a terminal event, the request fails instead of remaining pending.
 
 Actual interaction I/O is performed using the [libwebauthn][libwebauthn] library.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,7 +122,10 @@ any details that are not necessary for the UI to know (like the response
 channels mentioned above, which cannot be serialized over D-Bus anyway).
 
 USB, hybrid, and NFC handler events pass through shared request lifecycle
-handling, while each transport keeps its own public states.
+handling, while each transport keeps its own public states. All selected
+transports share one snapshot of their originating request. Terminal events
+are scoped to that request, so stale streams cannot complete a newer request.
+Cancellation wakes pending streams.
 
 Actual interaction I/O is performed using the [libwebauthn][libwebauthn] library.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -121,6 +121,9 @@ The `CredentialService` mostly just forwards events over to the UI service, minu
 any details that are not necessary for the UI to know (like the response
 channels mentioned above, which cannot be serialized over D-Bus anyway).
 
+USB, hybrid, and NFC handler events pass through shared request lifecycle
+handling, while each transport keeps its own public states.
+
 Actual interaction I/O is performed using the [libwebauthn][libwebauthn] library.
 
 [libwebauthn]: https://github.com/linux-credentials/libwebauthn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Improvements
 
+- daemon: Wake pending credential streams when their request is cancelled.
+- daemon: Ignore stale authenticator results from completed requests.
 - ui: Remove process ID from credential prompt.
 
 # 0.3.0 [2026-08-27]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 
+- daemon: Fail credential discovery when all selected transports stop without a result.
 - daemon: Wake pending credential streams when their request is cancelled.
 - daemon: Ignore stale authenticator results from completed requests.
 - ui: Remove process ID from credential prompt.

--- a/credentialsd/src/credential_service/mod.rs
+++ b/credentialsd/src/credential_service/mod.rs
@@ -2,6 +2,9 @@ pub mod hybrid;
 pub mod nfc;
 pub mod usb;
 
+#[cfg(test)]
+mod test_support;
+
 use std::{
     fmt::Debug,
     pin::Pin,
@@ -511,45 +514,10 @@ impl From<GetAssertionResponse> for AuthenticatorResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::time::Duration;
 
-    // Mock handlers for testing
-    #[derive(Debug)]
-    struct MockUsbHandler;
-    impl UsbHandler for MockUsbHandler {
-        fn start(
-            &self,
-            _request: &CredentialRequest,
-            _cancellation: CancellationToken,
-        ) -> impl Stream<Item = UsbEvent> + Send + Sized + Unpin + 'static {
-            futures::stream::empty()
-        }
-    }
-
-    #[derive(Debug)]
-    struct MockHybridHandler;
-    impl HybridHandler for MockHybridHandler {
-        fn start(
-            &self,
-            _request: &CredentialRequest,
-            _cancellation: CancellationToken,
-        ) -> impl Stream<Item = HybridEvent> + Unpin + Send + Sized + 'static {
-            futures::stream::empty()
-        }
-    }
-
-    #[derive(Debug)]
-    struct MockNfcHandler;
-    impl NfcHandler for MockNfcHandler {
-        fn start(
-            &self,
-            _request: &CredentialRequest,
-            _cancellation: CancellationToken,
-        ) -> impl Stream<Item = NfcEvent> + Send + Sized + Unpin + 'static {
-            futures::stream::empty()
-        }
-    }
+    use super::test_support::{EmptyTransport, ScriptedTransport};
+    use super::*;
 
     fn create_test_credential_response() -> CredentialResponse {
         use libwebauthn::ops::webauthn::GetAssertionResponse;
@@ -628,7 +596,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_request_returns_token_and_id() {
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, MockUsbHandler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
         let (tx, _rx) = oneshot::channel();
         let request = create_test_request().await;
 
@@ -642,7 +610,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cancel_request_triggers_cancellation() {
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, MockUsbHandler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
         let (tx, _rx) = oneshot::channel();
         let request = create_test_request().await;
 
@@ -679,7 +647,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_request_rejects_concurrent() {
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, MockUsbHandler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
         let (tx1, _rx1) = oneshot::channel();
         let (tx2, _rx2) = oneshot::channel();
         let request = create_test_request().await;
@@ -699,153 +667,9 @@ mod tests {
         );
     }
 
-    // Generic push-based handler that tracks cancellation.
-    // Before moving a handler into the service, call `get_handler_ref()` to obtain
-    // a `HandlerRef<T>` — a handle that exposes `shift_state()` and `was_cancelled()`
-    // for use in the test body.
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
-
-    /// Clone-able test handle for a `CancellationTrackingHandler<T>`.
-    /// Obtained via `handler.get_handler_ref()` before the handler is moved into the
-    /// service.
-    #[derive(Clone)]
-    struct HandlerRef<T> {
-        tx: UnboundedSender<T>,
-        cancelled: Arc<AtomicBool>,
-    }
-
-    impl<T> HandlerRef<T> {
-        /// Push the next state to be emitted by the handler's stream.
-        /// Panics if the stream receiver has been dropped.
-        fn shift_state(&self, state: T) {
-            self.tx.send(state).unwrap();
-        }
-
-        fn was_cancelled(&self) -> bool {
-            self.cancelled.load(Ordering::SeqCst)
-        }
-    }
-
-    struct CancellationTrackingHandler<T> {
-        tx: UnboundedSender<T>,
-        rx: std::sync::Mutex<Option<UnboundedReceiver<T>>>,
-        cancelled: Arc<AtomicBool>,
-    }
-
-    impl<T> std::fmt::Debug for CancellationTrackingHandler<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("CancellationTrackingHandler")
-                .field("cancelled", &self.cancelled.load(Ordering::SeqCst))
-                .finish_non_exhaustive()
-        }
-    }
-
-    impl<T> CancellationTrackingHandler<T> {
-        fn new() -> Self {
-            let (tx, rx) = unbounded_channel();
-            Self {
-                tx,
-                rx: std::sync::Mutex::new(Some(rx)),
-                cancelled: Arc::new(AtomicBool::new(false)),
-            }
-        }
-
-        /// Return a `HandlerRef` that can be kept by the test after this handler is
-        /// moved into the service.
-        fn get_handler_ref(&self) -> HandlerRef<T> {
-            HandlerRef {
-                tx: self.tx.clone(),
-                cancelled: self.cancelled.clone(),
-            }
-        }
-    }
-
-    /// Shared stream body for all three transport trait impls.
-    ///
-    /// Uses a `biased` `select!` with the cancellation branch first so that
-    /// cancellation always wins over a simultaneously-ready channel item. This
-    /// guarantees that no queued state is emitted once the token is cancelled,
-    /// making the "no emission after cancel" assertions in tests deterministic.
-    fn run_tracking_stream<T, E>(
-        rx: Option<UnboundedReceiver<T>>,
-        cancellation: CancellationToken,
-        cancelled: Arc<AtomicBool>,
-        wrap: impl Fn(T) -> E + Send + 'static,
-    ) -> impl Stream<Item = E> + Send + Unpin + 'static
-    where
-        T: Send + 'static,
-        E: Send + 'static,
-    {
-        Box::pin(async_stream::stream! {
-            let Some(mut rx) = rx else { return; };
-            // This allows to simulate when the handler detected cancellation,
-            // but still emit a single event after cancellation to simulate a
-            // race.
-            let mut cancel_detected = false;
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = cancellation.cancelled(), if !cancel_detected => {
-                        cancel_detected = true;
-                        cancelled.store(true, Ordering::SeqCst);
-                    }
-                    maybe = rx.recv() => match maybe {
-                        Some(state) => {
-                            yield wrap(state)
-                            if cancel_detected {
-                                break;
-                            }
-                        },
-                        None => break, // all senders dropped
-                    }
-                }
-            }
-        })
-    }
-
-    impl UsbHandler for CancellationTrackingHandler<UsbStateInternal> {
-        fn start(
-            &self,
-            _request: &CredentialRequest,
-            cancellation: CancellationToken,
-        ) -> impl Stream<Item = UsbEvent> + Send + Sized + Unpin + 'static {
-            let rx = self.rx.lock().unwrap().take();
-            run_tracking_stream(rx, cancellation, self.cancelled.clone(), |state| UsbEvent {
-                state,
-            })
-        }
-    }
-
-    impl HybridHandler for CancellationTrackingHandler<HybridStateInternal> {
-        fn start(
-            &self,
-            _request: &CredentialRequest,
-            cancellation: CancellationToken,
-        ) -> impl Stream<Item = HybridEvent> + Unpin + Send + Sized + 'static {
-            let rx = self.rx.lock().unwrap().take();
-            run_tracking_stream(rx, cancellation, self.cancelled.clone(), |state| {
-                HybridEvent { state }
-            })
-        }
-    }
-
-    impl NfcHandler for CancellationTrackingHandler<NfcStateInternal> {
-        fn start(
-            &self,
-            _request: &CredentialRequest,
-            cancellation: CancellationToken,
-        ) -> impl Stream<Item = NfcEvent> + Send + Sized + Unpin + 'static {
-            let rx = self.rx.lock().unwrap().take();
-            run_tracking_stream(rx, cancellation, self.cancelled.clone(), |state| NfcEvent {
-                state,
-            })
-        }
-    }
-
     #[tokio::test]
     async fn test_cancel_request_by_id() {
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, MockUsbHandler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -863,12 +687,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_handlers_all_cancelled() {
-        let usb_handler = CancellationTrackingHandler::<UsbStateInternal>::new();
-        let hybrid_handler = CancellationTrackingHandler::<HybridStateInternal>::new();
-        let usb_ref = usb_handler.get_handler_ref();
-        let hybrid_ref = hybrid_handler.get_handler_ref();
+        let (usb_handler, usb_ref) = ScriptedTransport::<UsbStateInternal>::new();
+        let (hybrid_handler, hybrid_ref) = ScriptedTransport::<HybridStateInternal>::new();
 
-        let service = CredentialService::new(hybrid_handler, MockNfcHandler, usb_handler);
+        let service = CredentialService::new(hybrid_handler, EmptyTransport, usb_handler);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -878,8 +700,8 @@ mod tests {
         let mut hybrid_stream = service.get_hybrid_credential().await;
 
         // Push and consume one state from each to confirm streams are live
-        usb_ref.shift_state(UsbStateInternal::Waiting);
-        hybrid_ref.shift_state(HybridStateInternal::Init("qr".to_string()));
+        usb_ref.emit(UsbStateInternal::Waiting);
+        hybrid_ref.emit(HybridStateInternal::Init("qr".to_string()));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));
         assert!(matches!(
             hybrid_stream.next().await,
@@ -888,9 +710,9 @@ mod tests {
 
         // Queue additional states that should never be emitted after cancellation.
         // These sit in the channel when cancel_request() fires.
-        usb_ref.shift_state(UsbStateInternal::Waiting);
-        usb_ref.shift_state(UsbStateInternal::Waiting);
-        hybrid_ref.shift_state(HybridStateInternal::Connecting);
+        usb_ref.emit(UsbStateInternal::Waiting);
+        usb_ref.emit(UsbStateInternal::Waiting);
+        hybrid_ref.emit(HybridStateInternal::Connecting);
 
         // Cancel the request — token is now cancelled synchronously
         service.cancel_request(request_id).await;
@@ -913,7 +735,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cancellation_cleans_up_request_context() {
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, MockUsbHandler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -933,7 +755,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cancel_with_unknown_id_is_noop() {
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, MockUsbHandler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -959,7 +781,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cancel_with_no_active_request_is_noop() {
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, MockUsbHandler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
 
         // Cancel when no request is active (should not crash or panic)
         service.cancel_request(12345).await;
@@ -976,7 +798,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_id_matches_on_init() {
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, MockUsbHandler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -998,15 +820,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_explicit_cancel_stops_all_transports() {
-        let usb_handler = CancellationTrackingHandler::<UsbStateInternal>::new();
-        let hybrid_handler = CancellationTrackingHandler::<HybridStateInternal>::new();
-        let usb_ref = usb_handler.get_handler_ref();
-        let hybrid_ref = hybrid_handler.get_handler_ref();
+        let (usb_handler, usb_ref) = ScriptedTransport::<UsbStateInternal>::new();
+        let (hybrid_handler, hybrid_ref) = ScriptedTransport::<HybridStateInternal>::new();
 
         assert!(!usb_ref.was_cancelled());
         assert!(!hybrid_ref.was_cancelled());
 
-        let service = CredentialService::new(hybrid_handler, MockNfcHandler, usb_handler);
+        let service = CredentialService::new(hybrid_handler, EmptyTransport, usb_handler);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -1016,8 +836,8 @@ mod tests {
         let mut hybrid_stream = service.get_hybrid_credential().await;
 
         // Push and consume one state each to confirm streams are live
-        usb_ref.shift_state(UsbStateInternal::Waiting);
-        hybrid_ref.shift_state(HybridStateInternal::Init("qr".to_string()));
+        usb_ref.emit(UsbStateInternal::Waiting);
+        hybrid_ref.emit(HybridStateInternal::Init("qr".to_string()));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));
         assert!(matches!(
             hybrid_stream.next().await,
@@ -1026,9 +846,9 @@ mod tests {
 
         // Queue additional states that should never be emitted after cancellation.
         // These sit in the channel when cancel_request() fires.
-        usb_ref.shift_state(UsbStateInternal::Waiting);
-        usb_ref.shift_state(UsbStateInternal::Waiting);
-        hybrid_ref.shift_state(HybridStateInternal::Connecting);
+        usb_ref.emit(UsbStateInternal::Waiting);
+        usb_ref.emit(UsbStateInternal::Waiting);
+        hybrid_ref.emit(HybridStateInternal::Connecting);
 
         // Explicitly cancel — token becomes cancelled synchronously
         service.cancel_request(request_id).await;
@@ -1037,9 +857,7 @@ mod tests {
             "Cancellation token should be triggered after cancel_request"
         );
         // Add explicit post-cancellation message.
-        usb_ref.shift_state(UsbStateInternal::Failed(CredentialServiceError::Internal(
-            "Cancelled".to_string(),
-        )));
+        usb_ref.fail(CredentialServiceError::Internal("Cancelled".to_string()));
 
         // biased select! polls cancellation first, discarding the queued states
         let usb_remaining: Vec<_> = usb_stream.collect().await;
@@ -1054,7 +872,7 @@ mod tests {
             "Hybrid should not emit any more states after cancellation"
         );
 
-        // Flags are set by run_tracking_stream when it observes the cancelled token
+        // Flags are set by ScriptedTransport when it observes the cancelled token.
         assert!(
             usb_ref.was_cancelled(),
             "USB handler should have detected cancellation"
@@ -1069,10 +887,9 @@ mod tests {
     async fn test_failed_request_triggers_cancellation() {
         use credentialsd_common::model::Error;
 
-        let usb_handler = CancellationTrackingHandler::<UsbStateInternal>::new();
-        let usb_ref = usb_handler.get_handler_ref();
+        let (usb_handler, usb_ref) = ScriptedTransport::<UsbStateInternal>::new();
 
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, usb_handler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, usb_handler);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -1081,12 +898,10 @@ mod tests {
         let mut usb_stream = service.get_usb_credential().await;
         assert!(!cancellation_token.is_cancelled());
 
-        usb_ref.shift_state(UsbStateInternal::Waiting);
+        usb_ref.emit(UsbStateInternal::Waiting);
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));
 
-        usb_ref.shift_state(UsbStateInternal::Failed(Error::Internal(
-            "test failure".to_string(),
-        )));
+        usb_ref.fail(Error::Internal("test failure".to_string()));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Failed(_))));
 
         // UsbStateStream calls complete_request on Failed, which cancels the token
@@ -1100,12 +915,10 @@ mod tests {
     async fn test_failed_request_cancels_other_transports() {
         use credentialsd_common::model::Error;
 
-        let usb_handler = CancellationTrackingHandler::<UsbStateInternal>::new();
-        let hybrid_handler = CancellationTrackingHandler::<HybridStateInternal>::new();
-        let usb_ref = usb_handler.get_handler_ref();
-        let hybrid_ref = hybrid_handler.get_handler_ref();
+        let (usb_handler, usb_ref) = ScriptedTransport::<UsbStateInternal>::new();
+        let (hybrid_handler, hybrid_ref) = ScriptedTransport::<HybridStateInternal>::new();
 
-        let service = CredentialService::new(hybrid_handler, MockNfcHandler, usb_handler);
+        let service = CredentialService::new(hybrid_handler, EmptyTransport, usb_handler);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -1115,7 +928,7 @@ mod tests {
         let mut hybrid_stream = service.get_hybrid_credential().await;
 
         // Confirm hybrid stream is live
-        hybrid_ref.shift_state(HybridStateInternal::Init("qr".to_string()));
+        hybrid_ref.emit(HybridStateInternal::Init("qr".to_string()));
         assert!(matches!(
             hybrid_stream.next().await,
             Some(HybridState::Init(_))
@@ -1123,13 +936,11 @@ mod tests {
 
         // Queue an extra hybrid state that should be discarded once USB fails.
         // It sits in the channel when complete_request() cancels the token.
-        hybrid_ref.shift_state(HybridStateInternal::Connecting);
+        hybrid_ref.emit(HybridStateInternal::Connecting);
 
-        // USB fails — UsbStateStream calls complete_request → token cancelled
-        usb_ref.shift_state(UsbStateInternal::Waiting);
-        usb_ref.shift_state(UsbStateInternal::Failed(Error::Internal(
-            "test".to_string(),
-        )));
+        // USB fails — CredentialStateStream calls complete_request → token cancelled
+        usb_ref.emit(UsbStateInternal::Waiting);
+        usb_ref.fail(Error::Internal("test".to_string()));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Failed(_))));
 
@@ -1154,10 +965,9 @@ mod tests {
     async fn test_completed_request_triggers_cancellation() {
         let credential_response = create_test_credential_response();
 
-        let usb_handler = CancellationTrackingHandler::<UsbStateInternal>::new();
-        let usb_ref = usb_handler.get_handler_ref();
+        let (usb_handler, usb_ref) = ScriptedTransport::<UsbStateInternal>::new();
 
-        let service = CredentialService::new(MockHybridHandler, MockNfcHandler, usb_handler);
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, usb_handler);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -1166,8 +976,8 @@ mod tests {
         let mut usb_stream = service.get_usb_credential().await;
         assert!(!cancellation_token.is_cancelled());
 
-        usb_ref.shift_state(UsbStateInternal::Waiting);
-        usb_ref.shift_state(UsbStateInternal::Completed(credential_response));
+        usb_ref.emit(UsbStateInternal::Waiting);
+        usb_ref.complete(credential_response);
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Completed)));
 
@@ -1182,12 +992,10 @@ mod tests {
     async fn test_completed_request_cancels_other_transports() {
         let credential_response = create_test_credential_response();
 
-        let usb_handler = CancellationTrackingHandler::<UsbStateInternal>::new();
-        let hybrid_handler = CancellationTrackingHandler::<HybridStateInternal>::new();
-        let usb_ref = usb_handler.get_handler_ref();
-        let hybrid_ref = hybrid_handler.get_handler_ref();
+        let (usb_handler, usb_ref) = ScriptedTransport::<UsbStateInternal>::new();
+        let (hybrid_handler, hybrid_ref) = ScriptedTransport::<HybridStateInternal>::new();
 
-        let service = CredentialService::new(hybrid_handler, MockNfcHandler, usb_handler);
+        let service = CredentialService::new(hybrid_handler, EmptyTransport, usb_handler);
         let request = create_test_request().await;
         let (tx, _rx) = oneshot::channel();
 
@@ -1197,7 +1005,7 @@ mod tests {
         let mut hybrid_stream = service.get_hybrid_credential().await;
 
         // Confirm hybrid stream is live
-        hybrid_ref.shift_state(HybridStateInternal::Init("qr".to_string()));
+        hybrid_ref.emit(HybridStateInternal::Init("qr".to_string()));
         assert!(matches!(
             hybrid_stream.next().await,
             Some(HybridState::Init(_))
@@ -1205,11 +1013,11 @@ mod tests {
 
         // Queue an extra hybrid state that should be discarded once USB completes.
         // It sits in the channel when complete_request() cancels the token.
-        hybrid_ref.shift_state(HybridStateInternal::Connecting);
+        hybrid_ref.emit(HybridStateInternal::Connecting);
 
-        // USB completes — UsbStateStream calls complete_request → token cancelled
-        usb_ref.shift_state(UsbStateInternal::Waiting);
-        usb_ref.shift_state(UsbStateInternal::Completed(credential_response));
+        // USB completes — CredentialStateStream calls complete_request → token cancelled
+        usb_ref.emit(UsbStateInternal::Waiting);
+        usb_ref.complete(credential_response);
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Completed)));
 

--- a/credentialsd/src/credential_service/mod.rs
+++ b/credentialsd/src/credential_service/mod.rs
@@ -68,6 +68,13 @@ fn persistent_token_store() -> Arc<dyn PersistentTokenStore> {
 #[derive(Debug)]
 struct RequestMarker;
 
+#[derive(Clone, Debug)]
+struct RequestLifecycle {
+    request_id: RequestId,
+    request_marker: Arc<RequestMarker>,
+    cancellation: CancellationToken,
+}
+
 #[derive(Debug)]
 struct RequestContext {
     request: CredentialRequest,
@@ -78,6 +85,14 @@ struct RequestContext {
 }
 
 impl RequestContext {
+    fn lifecycle(&self) -> RequestLifecycle {
+        RequestLifecycle {
+            request_id: self.request_id,
+            request_marker: self.request_marker.clone(),
+            cancellation: self.cancellation.clone(),
+        }
+    }
+
     fn send_response(self, response: Result<CredentialResponse, CredentialServiceError>) {
         if self.response_channel.send(response).is_err() {
             tracing::error!(
@@ -129,31 +144,60 @@ impl<H: HybridHandler + Debug, N: NfcHandler + Debug, U: UsbHandler + Debug>
 impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
     CredentialService<H, N, U>
 {
+    fn current_request(&self) -> Option<(CredentialRequest, RequestLifecycle)> {
+        self.ctx
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|ctx| (ctx.request.clone(), ctx.lifecycle()))
+    }
+
+    fn hybrid_credential_stream(
+        &self,
+        request: &CredentialRequest,
+        lifecycle: RequestLifecycle,
+    ) -> Pin<Box<dyn Stream<Item = HybridState> + Send + 'static>> {
+        let stream = self
+            .hybrid_handler
+            .lock()
+            .unwrap()
+            .start(request, lifecycle.cancellation.clone());
+        credential_state_stream(stream, self.ctx.clone(), lifecycle)
+    }
+
+    fn usb_credential_stream(
+        &self,
+        request: &CredentialRequest,
+        lifecycle: RequestLifecycle,
+    ) -> Pin<Box<dyn Stream<Item = UsbState> + Send + 'static>> {
+        let stream = self
+            .usb_handler
+            .lock()
+            .unwrap()
+            .start(request, lifecycle.cancellation.clone());
+        credential_state_stream(stream, self.ctx.clone(), lifecycle)
+    }
+
+    #[cfg_attr(not(test), expect(dead_code))]
+    fn nfc_credential_stream(
+        &self,
+        request: &CredentialRequest,
+        lifecycle: RequestLifecycle,
+    ) -> Pin<Box<dyn Stream<Item = NfcState> + Send + 'static>> {
+        let stream = self
+            ._nfc_handler
+            .lock()
+            .unwrap()
+            .start(request, lifecycle.cancellation.clone());
+        credential_state_stream(stream, self.ctx.clone(), lifecycle)
+    }
+
+    #[cfg(test)]
     async fn get_hybrid_credential(
         &self,
     ) -> Pin<Box<dyn Stream<Item = HybridState> + Send + 'static>> {
-        let guard = self.ctx.lock().unwrap();
-        if let Some(RequestContext {
-            ref request,
-            ref cancellation,
-            ref request_marker,
-            request_id,
-            ..
-        }) = *guard
-        {
-            let stream = self
-                .hybrid_handler
-                .lock()
-                .unwrap()
-                .start(request, cancellation.clone());
-            let ctx = self.ctx.clone();
-            credential_state_stream(
-                stream,
-                ctx,
-                request_id,
-                request_marker.clone(),
-                cancellation.clone(),
-            )
+        if let Some((request, lifecycle)) = self.current_request() {
+            self.hybrid_credential_stream(&request, lifecycle)
         } else {
             tracing::error!(
                 "Attempted to start hybrid credential flow, but no request context was found."
@@ -162,29 +206,10 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
         }
     }
 
+    #[cfg(test)]
     async fn get_usb_credential(&self) -> Pin<Box<dyn Stream<Item = UsbState> + Send + 'static>> {
-        let guard = self.ctx.lock().unwrap();
-        if let Some(RequestContext {
-            ref request,
-            ref cancellation,
-            ref request_marker,
-            request_id,
-            ..
-        }) = *guard
-        {
-            let stream = self
-                .usb_handler
-                .lock()
-                .unwrap()
-                .start(request, cancellation.clone());
-            let ctx = self.ctx.clone();
-            credential_state_stream(
-                stream,
-                ctx,
-                request_id,
-                request_marker.clone(),
-                cancellation.clone(),
-            )
+        if let Some((request, lifecycle)) = self.current_request() {
+            self.usb_credential_stream(&request, lifecycle)
         } else {
             tracing::error!(
                 "Attempted to start usb credential flow, but no request context was found."
@@ -193,29 +218,10 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
         }
     }
 
+    #[cfg(test)]
     async fn _get_nfc_credential(&self) -> Pin<Box<dyn Stream<Item = NfcState> + Send + 'static>> {
-        let guard = self.ctx.lock().unwrap();
-        if let Some(RequestContext {
-            ref request,
-            ref cancellation,
-            ref request_marker,
-            request_id,
-            ..
-        }) = *guard
-        {
-            let stream = self
-                ._nfc_handler
-                .lock()
-                .unwrap()
-                .start(request, cancellation.clone());
-            let ctx = self.ctx.clone();
-            credential_state_stream(
-                stream,
-                ctx,
-                request_id,
-                request_marker.clone(),
-                cancellation.clone(),
-            )
+        if let Some((request, lifecycle)) = self.current_request() {
+            self.nfc_credential_stream(&request, lifecycle)
         } else {
             tracing::error!(
                 "Attempted to start nfc credential flow, but no request context was found."
@@ -223,6 +229,7 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
             todo!("Handle error when context is not set up.")
         }
     }
+
 }
 
 #[async_trait]
@@ -301,11 +308,16 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send> Manage
         &self,
     ) -> Pin<Box<dyn Stream<Item = DeviceStateUpdate> + Send + 'static>> {
         let available_transports = available_transports().await;
+        let Some((request, lifecycle)) = self.current_request() else {
+            tracing::error!(
+                "Attempted to start credential discovery, but no request context was found."
+            );
+            return futures::stream::empty().boxed();
+        };
         let mut selected_transports = Vec::new();
         if available_transports.contains(&libwebauthn::Transport::Usb) {
             let usb = self
-                .get_usb_credential()
-                .await
+                .usb_credential_stream(&request, lifecycle.clone())
                 .map(DeviceStateUpdate::from)
                 .boxed();
             selected_transports.push(usb);
@@ -320,8 +332,7 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send> Manage
         or verification message is sent.
         if available_transports.contains(&libwebauthn::Transport::Nfc) {
             let nfc = self
-                .get_nfc_credential()
-                .await
+                .nfc_credential_stream(&request, lifecycle.clone())
                 .map(DeviceStateUpdate::from)
                 .boxed();
             selected_transports.push(nfc);
@@ -329,8 +340,7 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send> Manage
         */
         if available_transports.contains(&libwebauthn::Transport::Hybrid) {
             let hybrid = self
-                .get_hybrid_credential()
-                .await
+                .hybrid_credential_stream(&request, lifecycle.clone())
                 .map(DeviceStateUpdate::from)
                 .boxed();
             selected_transports.push(hybrid);
@@ -414,9 +424,7 @@ impl TransportEvent for NfcEvent {
 fn credential_state_stream<S, E>(
     mut inner: S,
     ctx: Arc<Mutex<Option<RequestContext>>>,
-    request_id: RequestId,
-    request_marker: Arc<RequestMarker>,
-    cancellation_token: CancellationToken,
+    lifecycle: RequestLifecycle,
 ) -> Pin<Box<dyn Stream<Item = E::PublicState> + Send + 'static>>
 where
     S: Stream<Item = E> + Unpin + Send + 'static,
@@ -425,7 +433,7 @@ where
 {
     Box::pin(async_stream::stream! {
         loop {
-            let Some(event) = cancellation_token
+            let Some(event) = lifecycle.cancellation
                 .run_until_cancelled(inner.next())
                 .await
                 .flatten()
@@ -433,13 +441,13 @@ where
                 break;
             };
 
-            if cancellation_token.is_cancelled() {
+            if lifecycle.cancellation.is_cancelled() {
                 break;
             }
 
             let (state, result) = event.into_state_and_result();
             if let Some(result) = result {
-                if !complete_request(&ctx, request_id, &request_marker, result) {
+                if !complete_request(&ctx, &lifecycle, result) {
                     break;
                 }
                 yield state;
@@ -487,17 +495,16 @@ impl From<UsbState> for DeviceStateUpdate {
 
 fn complete_request(
     ctx: &Mutex<Option<RequestContext>>,
-    request_id: RequestId,
-    request_marker: &Arc<RequestMarker>,
+    lifecycle: &RequestLifecycle,
     response: Result<CredentialResponse, CredentialServiceError>,
 ) -> bool {
     let request_ctx = ctx.lock().unwrap().take_if(|request_ctx| {
-        request_ctx.request_id == request_id
-            && Arc::ptr_eq(&request_ctx.request_marker, request_marker)
+        request_ctx.request_id == lifecycle.request_id
+            && Arc::ptr_eq(&request_ctx.request_marker, &lifecycle.request_marker)
     });
     let Some(request_ctx) = request_ctx else {
         tracing::debug!(
-            request_id,
+            request_id = lifecycle.request_id,
             "Ignoring terminal event for a request that is no longer active."
         );
         return false;
@@ -713,7 +720,6 @@ mod tests {
         let mut usb_stream = service.get_usb_credential().await;
         let mut hybrid_stream = service.get_hybrid_credential().await;
 
-        // Push and consume one state from each to confirm streams are live
         usb_ref.emit(UsbStateInternal::Waiting);
         hybrid_ref.emit(HybridStateInternal::Init("qr".to_string()));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));
@@ -722,18 +728,13 @@ mod tests {
             Some(HybridState::Init(_))
         ));
 
-        // Queue additional states that should never be emitted after cancellation.
-        // These sit in the channel when cancel_request() fires.
         usb_ref.emit(UsbStateInternal::Waiting);
         usb_ref.emit(UsbStateInternal::Waiting);
         hybrid_ref.emit(HybridStateInternal::Connecting);
 
-        // Cancel the request — token is now cancelled synchronously
         service.cancel_request(request_id).await;
         assert!(cancellation_token.is_cancelled());
 
-        // biased select! polls cancellation first each iteration, discarding
-        // the queued states before they can be emitted.
         let usb_remaining: Vec<_> = usb_stream.collect().await;
         let hybrid_remaining: Vec<_> = hybrid_stream.collect().await;
 
@@ -921,7 +922,7 @@ mod tests {
         let result = rx.await.expect("request result should be sent");
         assert!(matches!(result, Err(Error::Internal(message)) if message == "test failure"));
 
-        // CredentialStateStream calls complete_request on Failed, which cancels the token
+        // The lifecycle stream completes a failed request and cancels its token.
         assert!(
             cancellation_token.is_cancelled(),
             "Cancellation token should be triggered when request fails"
@@ -1048,14 +1049,17 @@ mod tests {
             request_marker: request_marker.clone(),
             cancellation: cancellation.clone(),
         })));
+        let lifecycle = RequestLifecycle {
+            request_id: 1,
+            request_marker,
+            cancellation,
+        };
         let mut stream = credential_state_stream(
             futures::stream::iter([UsbEvent {
                 state: UsbStateInternal::Waiting,
             }]),
             ctx.clone(),
-            1,
-            request_marker,
-            cancellation,
+            lifecycle,
         );
 
         assert!(stream.next().await.is_none());
@@ -1078,6 +1082,11 @@ mod tests {
             request_marker: request_marker.clone(),
             cancellation: cancellation.clone(),
         })));
+        let lifecycle = RequestLifecycle {
+            request_id: 1,
+            request_marker,
+            cancellation: cancellation.clone(),
+        };
         let (polled_tx, polled_rx) = oneshot::channel();
         let mut polled_tx = Some(polled_tx);
         let pending_inner = futures::stream::poll_fn(move |_cx| {
@@ -1086,13 +1095,7 @@ mod tests {
             }
             Poll::<Option<UsbEvent>>::Pending
         });
-        let mut stream = credential_state_stream(
-            pending_inner,
-            ctx.clone(),
-            1,
-            request_marker,
-            cancellation.clone(),
-        );
+        let mut stream = credential_state_stream(pending_inner, ctx.clone(), lifecycle);
 
         let waiting_task = tokio::spawn(async move { stream.next().await });
         polled_rx.await.expect("inner stream should be polled");
@@ -1129,9 +1132,11 @@ mod tests {
                 state: UsbStateInternal::Completed(create_test_credential_response()),
             }]),
             ctx.clone(),
-            1,
-            stale_request_marker,
-            stale_cancellation.clone(),
+            RequestLifecycle {
+                request_id: 1,
+                request_marker: stale_request_marker,
+                cancellation: stale_cancellation.clone(),
+            },
         );
 
         assert!(stale_stream.next().await.is_none());
@@ -1174,7 +1179,7 @@ mod tests {
         // It sits in the channel when complete_request() cancels the token.
         hybrid_ref.emit(HybridStateInternal::Connecting);
 
-        // USB fails — CredentialStateStream calls complete_request → token cancelled
+        // USB failure completes the request and cancels the token.
         usb_ref.emit(UsbStateInternal::Waiting);
         usb_ref.fail(Error::Internal("test".to_string()));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));
@@ -1219,7 +1224,7 @@ mod tests {
 
         assert!(rx.await.expect("request result should be sent").is_ok());
 
-        // CredentialStateStream calls complete_request on Completed, which cancels the token
+        // The lifecycle stream completes the request and cancels its token.
         assert!(
             cancellation_token.is_cancelled(),
             "Cancellation token should be triggered when request completes successfully"
@@ -1253,7 +1258,7 @@ mod tests {
         // It sits in the channel when complete_request() cancels the token.
         hybrid_ref.emit(HybridStateInternal::Connecting);
 
-        // USB completes — CredentialStateStream calls complete_request → token cancelled
+        // USB completion completes the request and cancels the token.
         usb_ref.emit(UsbStateInternal::Waiting);
         usb_ref.complete(credential_response);
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));

--- a/credentialsd/src/credential_service/mod.rs
+++ b/credentialsd/src/credential_service/mod.rs
@@ -9,11 +9,10 @@ use std::{
     fmt::Debug,
     pin::Pin,
     sync::{Arc, Mutex, OnceLock},
-    task::Poll,
 };
 
 use async_trait::async_trait;
-use futures_lite::{FutureExt, Stream, StreamExt};
+use futures_lite::{Stream, StreamExt};
 use libwebauthn::{
     self,
     ops::webauthn::{GetAssertionResponse, MakeCredentialResponse},
@@ -142,11 +141,7 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
                 .unwrap()
                 .start(request, cancellation.clone());
             let ctx = self.ctx.clone();
-            Box::pin(HybridStateStream {
-                inner: stream,
-                ctx,
-                cancellation_token: cancellation.clone(),
-            })
+            credential_state_stream(stream, ctx, cancellation.clone())
         } else {
             tracing::error!(
                 "Attempted to start hybrid credential flow, but no request context was found."
@@ -169,11 +164,7 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
                 .unwrap()
                 .start(request, cancellation.clone());
             let ctx = self.ctx.clone();
-            Box::pin(UsbStateStream {
-                inner: stream,
-                ctx,
-                cancellation_token: cancellation.clone(),
-            })
+            credential_state_stream(stream, ctx, cancellation.clone())
         } else {
             tracing::error!(
                 "Attempted to start usb credential flow, but no request context was found."
@@ -196,11 +187,7 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
                 .unwrap()
                 .start(request, cancellation.clone());
             let ctx = self.ctx.clone();
-            Box::pin(NfcStateStream {
-                inner: stream,
-                ctx,
-                cancellation_token: cancellation.clone(),
-            })
+            credential_state_stream(stream, ctx, cancellation.clone())
         } else {
             tracing::error!(
                 "Attempted to start nfc credential flow, but no request context was found."
@@ -323,126 +310,103 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send> Manage
     }
 }
 
-pub struct HybridStateStream<H> {
-    inner: H,
-    ctx: Arc<Mutex<Option<RequestContext>>>,
-    cancellation_token: CancellationToken,
+/// An event emitted by a credential transport.
+///
+/// Transport implementations keep their privileged internal states private and
+/// use this trait to expose the corresponding public state. Terminal events
+/// additionally carry the result used to complete the active request.
+trait TransportEvent {
+    type PublicState;
+
+    fn into_state_and_result(
+        self,
+    ) -> (
+        Self::PublicState,
+        Option<Result<CredentialResponse, CredentialServiceError>>,
+    );
 }
 
-impl<H> Stream for HybridStateStream<H>
-where
-    H: Stream<Item = HybridEvent> + Unpin + Sized,
-{
-    type Item = HybridState;
+impl TransportEvent for HybridEvent {
+    type PublicState = HybridState;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        let ctx = &self.ctx.clone();
-        let cancellation_token = self.cancellation_token.clone();
-        match Box::pin(Box::pin(self).as_mut().inner.next()).poll(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Some(HybridEvent { state })) => {
-                if cancellation_token.is_cancelled() {
-                    return Poll::Ready(None);
-                }
-                match &state {
-                    HybridStateInternal::Completed(response) => {
-                        complete_request(ctx, Ok(response.clone()));
-                    }
-                    HybridStateInternal::Failed(err) => {
-                        complete_request(ctx, Err(err.clone()));
-                    }
-                    _ => {}
-                }
-                Poll::Ready(Some(state.into()))
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-        }
+    fn into_state_and_result(
+        self,
+    ) -> (
+        Self::PublicState,
+        Option<Result<CredentialResponse, CredentialServiceError>>,
+    ) {
+        let result = match &self.state {
+            HybridStateInternal::Completed(response) => Some(Ok(response.clone())),
+            HybridStateInternal::Failed(error) => Some(Err(error.clone())),
+            _ => None,
+        };
+        (self.state.into(), result)
     }
 }
 
-struct UsbStateStream<H> {
-    inner: H,
-    ctx: Arc<Mutex<Option<RequestContext>>>,
-    cancellation_token: CancellationToken,
-}
+impl TransportEvent for UsbEvent {
+    type PublicState = UsbState;
 
-impl<H> Stream for UsbStateStream<H>
-where
-    H: Stream<Item = UsbEvent> + Unpin + Sized,
-{
-    type Item = UsbState;
-
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        let ctx = &self.ctx.clone();
-        let cancellation_token = self.cancellation_token.clone();
-        match Box::pin(Box::pin(self).as_mut().inner.next()).poll(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Some(UsbEvent { state })) => {
-                if cancellation_token.is_cancelled() {
-                    return Poll::Ready(None);
-                }
-                match &state {
-                    UsbStateInternal::Completed(response) => {
-                        complete_request(ctx, Ok(response.clone()));
-                    }
-                    UsbStateInternal::Failed(error) => {
-                        complete_request(ctx, Err(error.clone()));
-                    }
-                    _ => {}
-                }
-                Poll::Ready(Some(state.into()))
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-        }
+    fn into_state_and_result(
+        self,
+    ) -> (
+        Self::PublicState,
+        Option<Result<CredentialResponse, CredentialServiceError>>,
+    ) {
+        let result = match &self.state {
+            UsbStateInternal::Completed(response) => Some(Ok(response.clone())),
+            UsbStateInternal::Failed(error) => Some(Err(error.clone())),
+            _ => None,
+        };
+        (self.state.into(), result)
     }
 }
 
-#[expect(unused)]
-struct NfcStateStream<H> {
-    inner: H,
-    ctx: Arc<Mutex<Option<RequestContext>>>,
-    cancellation_token: CancellationToken,
+impl TransportEvent for NfcEvent {
+    type PublicState = NfcState;
+
+    fn into_state_and_result(
+        self,
+    ) -> (
+        Self::PublicState,
+        Option<Result<CredentialResponse, CredentialServiceError>>,
+    ) {
+        let result = match &self.state {
+            NfcStateInternal::Completed(response) => Some(Ok(response.clone())),
+            NfcStateInternal::Failed(error) => Some(Err(error.clone())),
+            _ => None,
+        };
+        (self.state.into(), result)
+    }
 }
 
-impl<H> Stream for NfcStateStream<H>
+/// Applies request lifecycle handling to a transport's stream of events.
+fn credential_state_stream<S, E>(
+    mut inner: S,
+    ctx: Arc<Mutex<Option<RequestContext>>>,
+    cancellation_token: CancellationToken,
+) -> Pin<Box<dyn Stream<Item = E::PublicState> + Send + 'static>>
 where
-    H: Stream<Item = NfcEvent> + Unpin + Sized,
+    S: Stream<Item = E> + Unpin + Send + 'static,
+    E: TransportEvent + Send + 'static,
+    E::PublicState: Send + 'static,
 {
-    type Item = NfcState;
-
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        let ctx = &self.ctx.clone();
-        let cancellation_token = self.cancellation_token.clone();
-        match Box::pin(Box::pin(self).as_mut().inner.next()).poll(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Some(NfcEvent { state })) => {
-                if cancellation_token.is_cancelled() {
-                    return Poll::Ready(None);
-                }
-
-                match &state {
-                    NfcStateInternal::Completed(response) => {
-                        complete_request(ctx, Ok(response.clone()));
-                    }
-                    NfcStateInternal::Failed(error) => {
-                        complete_request(ctx, Err(error.clone()));
-                    }
-                    _ => {}
-                }
-                Poll::Ready(Some(state.into()))
+    Box::pin(async_stream::stream! {
+        while let Some(event) = inner.next().await {
+            if cancellation_token.is_cancelled() {
+                break;
             }
-            Poll::Ready(None) => Poll::Ready(None),
+
+            let (state, result) = event.into_state_and_result();
+            if let Some(result) = result {
+                complete_request(&ctx, result);
+                yield state;
+                break;
+            }
+
+            yield state;
         }
-    }
+    })
 }
 
 pub enum DeviceStateUpdate {
@@ -891,7 +855,7 @@ mod tests {
 
         let service = CredentialService::new(EmptyTransport, EmptyTransport, usb_handler);
         let request = create_test_request().await;
-        let (tx, _rx) = oneshot::channel();
+        let (tx, rx) = oneshot::channel();
 
         let (_request_id, cancellation_token) = service.init_request(&request, tx).await.unwrap();
 
@@ -904,10 +868,116 @@ mod tests {
         usb_ref.fail(Error::Internal("test failure".to_string()));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Failed(_))));
 
-        // UsbStateStream calls complete_request on Failed, which cancels the token
+        let result = rx.await.expect("request result should be sent");
+        assert!(matches!(result, Err(Error::Internal(message)) if message == "test failure"));
+
+        // CredentialStateStream calls complete_request on Failed, which cancels the token
         assert!(
             cancellation_token.is_cancelled(),
             "Cancellation token should be triggered when request fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_scripted_nfc_transport_uses_generic_lifecycle_stream() {
+        use credentialsd_common::model::Error;
+
+        let (nfc_handler, nfc_controller) = ScriptedTransport::<NfcStateInternal>::new();
+        let service = CredentialService::new(EmptyTransport, nfc_handler, EmptyTransport);
+        let request = create_test_request().await;
+        let (tx, rx) = oneshot::channel();
+
+        let (_request_id, cancellation_token) = service.init_request(&request, tx).await.unwrap();
+        let mut nfc_stream = service._get_nfc_credential().await;
+
+        nfc_controller.emit(NfcStateInternal::Waiting);
+        assert!(matches!(nfc_stream.next().await, Some(NfcState::Waiting)));
+
+        nfc_controller.fail(Error::Internal("mock NFC failure".to_string()));
+        assert!(matches!(nfc_stream.next().await, Some(NfcState::Failed(_))));
+        assert!(cancellation_token.is_cancelled());
+
+        let result = rx.await.expect("request result should be sent");
+        assert!(matches!(result, Err(Error::Internal(message)) if message == "mock NFC failure"));
+    }
+
+    #[tokio::test]
+    async fn test_scripted_nfc_transport_propagates_successful_response() {
+        let (nfc_handler, nfc_controller) = ScriptedTransport::<NfcStateInternal>::new();
+        let service = CredentialService::new(EmptyTransport, nfc_handler, EmptyTransport);
+        let request = create_test_request().await;
+        let (tx, rx) = oneshot::channel();
+
+        let (_request_id, cancellation_token) = service.init_request(&request, tx).await.unwrap();
+        let mut nfc_stream = service._get_nfc_credential().await;
+
+        nfc_controller.emit(NfcStateInternal::Waiting);
+        assert!(matches!(nfc_stream.next().await, Some(NfcState::Waiting)));
+
+        nfc_controller.complete(create_test_credential_response());
+        assert!(matches!(nfc_stream.next().await, Some(NfcState::Completed)));
+        assert!(cancellation_token.is_cancelled());
+
+        let result = rx.await.expect("request result should be sent");
+        let Ok(CredentialResponse::GetPublicKeyCredentialResponse(response)) = result else {
+            panic!("NFC completion should propagate the credential response");
+        };
+        assert_eq!(response.attachment_modality, "cross-platform");
+    }
+
+    #[tokio::test]
+    async fn test_scripted_hybrid_transport_propagates_failure() {
+        use credentialsd_common::model::Error;
+
+        let (hybrid_handler, hybrid_controller) = ScriptedTransport::<HybridStateInternal>::new();
+        let service = CredentialService::new(hybrid_handler, EmptyTransport, EmptyTransport);
+        let request = create_test_request().await;
+        let (tx, rx) = oneshot::channel();
+
+        let (_request_id, cancellation_token) = service.init_request(&request, tx).await.unwrap();
+        let mut hybrid_stream = service.get_hybrid_credential().await;
+
+        hybrid_controller.emit(HybridStateInternal::Connecting);
+        assert!(matches!(
+            hybrid_stream.next().await,
+            Some(HybridState::Connecting)
+        ));
+
+        hybrid_controller.fail(Error::NoCredentials);
+        assert!(matches!(
+            hybrid_stream.next().await,
+            Some(HybridState::Failed(Error::NoCredentials))
+        ));
+        assert!(cancellation_token.is_cancelled());
+
+        let result = rx.await.expect("request result should be sent");
+        assert!(matches!(result, Err(Error::NoCredentials)));
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_stream_discards_event_after_cancellation() {
+        let request = create_test_request().await;
+        let (response_channel, _response_rx) = oneshot::channel();
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let ctx = Arc::new(Mutex::new(Some(RequestContext {
+            request,
+            response_channel,
+            request_id: 1,
+            cancellation: cancellation.clone(),
+        })));
+        let mut stream = credential_state_stream(
+            futures::stream::iter([UsbEvent {
+                state: UsbStateInternal::Waiting,
+            }]),
+            ctx.clone(),
+            cancellation,
+        );
+
+        assert!(stream.next().await.is_none());
+        assert!(
+            ctx.lock().unwrap().is_some(),
+            "discarding a stale event must not complete the active request"
         );
     }
 
@@ -969,7 +1039,7 @@ mod tests {
 
         let service = CredentialService::new(EmptyTransport, EmptyTransport, usb_handler);
         let request = create_test_request().await;
-        let (tx, _rx) = oneshot::channel();
+        let (tx, rx) = oneshot::channel();
 
         let (_request_id, cancellation_token) = service.init_request(&request, tx).await.unwrap();
 
@@ -981,7 +1051,9 @@ mod tests {
         assert!(matches!(usb_stream.next().await, Some(UsbState::Waiting)));
         assert!(matches!(usb_stream.next().await, Some(UsbState::Completed)));
 
-        // UsbStateStream calls complete_request on Completed, which cancels the token
+        assert!(rx.await.expect("request result should be sent").is_ok());
+
+        // CredentialStateStream calls complete_request on Completed, which cancels the token
         assert!(
             cancellation_token.is_cancelled(),
             "Cancellation token should be triggered when request completes successfully"

--- a/credentialsd/src/credential_service/mod.rs
+++ b/credentialsd/src/credential_service/mod.rs
@@ -392,7 +392,15 @@ where
     E::PublicState: Send + 'static,
 {
     Box::pin(async_stream::stream! {
-        while let Some(event) = inner.next().await {
+        loop {
+            let Some(event) = cancellation_token
+                .run_until_cancelled(inner.next())
+                .await
+                .flatten()
+            else {
+                break;
+            };
+
             if cancellation_token.is_cancelled() {
                 break;
             }
@@ -478,7 +486,7 @@ impl From<GetAssertionResponse> for AuthenticatorResponse {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{task::Poll, time::Duration};
 
     use super::test_support::{EmptyTransport, ScriptedTransport};
     use super::*;
@@ -978,6 +986,42 @@ mod tests {
         assert!(
             ctx.lock().unwrap().is_some(),
             "discarding a stale event must not complete the active request"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_stream_wakes_when_cancelled_while_inner_is_pending() {
+        let request = create_test_request().await;
+        let (response_channel, _response_rx) = oneshot::channel();
+        let cancellation = CancellationToken::new();
+        let ctx = Arc::new(Mutex::new(Some(RequestContext {
+            request,
+            response_channel,
+            request_id: 1,
+            cancellation: cancellation.clone(),
+        })));
+        let (polled_tx, polled_rx) = oneshot::channel();
+        let mut polled_tx = Some(polled_tx);
+        let pending_inner = futures::stream::poll_fn(move |_cx| {
+            if let Some(polled_tx) = polled_tx.take() {
+                _ = polled_tx.send(());
+            }
+            Poll::<Option<UsbEvent>>::Pending
+        });
+        let mut stream = credential_state_stream(pending_inner, ctx.clone(), cancellation.clone());
+
+        let waiting_task = tokio::spawn(async move { stream.next().await });
+        polled_rx.await.expect("inner stream should be polled");
+        cancellation.cancel();
+
+        let event = tokio::time::timeout(Duration::from_secs(1), waiting_task)
+            .await
+            .expect("cancellation should wake the lifecycle stream")
+            .expect("stream task should not panic");
+        assert!(event.is_none());
+        assert!(
+            ctx.lock().unwrap().is_some(),
+            "cancelling a pending stream must not complete the active request"
         );
     }
 

--- a/credentialsd/src/credential_service/mod.rs
+++ b/credentialsd/src/credential_service/mod.rs
@@ -1070,6 +1070,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_lifecycle_stream_discards_terminal_event_ready_during_cancellation() {
+        let request = create_test_request().await;
+        let (response_channel, mut response_rx) = oneshot::channel();
+        let cancellation = CancellationToken::new();
+        let cancellation_from_inner = cancellation.clone();
+        let request_marker = Arc::new(RequestMarker);
+        let ctx = Arc::new(Mutex::new(Some(RequestContext {
+            request,
+            response_channel,
+            request_id: 1,
+            request_marker: request_marker.clone(),
+            cancellation: cancellation.clone(),
+        })));
+        let lifecycle = RequestLifecycle {
+            request_id: 1,
+            request_marker,
+            cancellation,
+        };
+        let mut event = Some(UsbEvent {
+            state: UsbStateInternal::Completed(create_test_credential_response()),
+        });
+        let inner = futures::stream::poll_fn(move |_cx| {
+            cancellation_from_inner.cancel();
+            Poll::Ready(event.take())
+        });
+        let mut stream = credential_state_stream(inner, ctx.clone(), lifecycle);
+
+        assert!(stream.next().await.is_none());
+        assert!(
+            ctx.lock().unwrap().is_some(),
+            "a terminal event concurrent with cancellation must not complete the request"
+        );
+        assert!(matches!(
+            response_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
     async fn test_lifecycle_stream_wakes_when_cancelled_while_inner_is_pending() {
         let request = create_test_request().await;
         let (response_channel, _response_rx) = oneshot::channel();

--- a/credentialsd/src/credential_service/mod.rs
+++ b/credentialsd/src/credential_service/mod.rs
@@ -229,7 +229,6 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
             todo!("Handle error when context is not set up.")
         }
     }
-
 }
 
 #[async_trait]

--- a/credentialsd/src/credential_service/mod.rs
+++ b/credentialsd/src/credential_service/mod.rs
@@ -229,6 +229,15 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
             todo!("Handle error when context is not set up.")
         }
     }
+
+    fn merge_discovery_streams(
+        &self,
+        selected_transports: Vec<Pin<Box<dyn Stream<Item = DeviceStateUpdate> + Send + 'static>>>,
+        lifecycle: RequestLifecycle,
+    ) -> Pin<Box<dyn Stream<Item = DeviceStateUpdate> + Send + 'static>> {
+        let selected_transports = futures::stream::select_all(selected_transports);
+        discovery_state_stream(selected_transports, self.ctx.clone(), lifecycle)
+    }
 }
 
 #[async_trait]
@@ -345,7 +354,7 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send> Manage
             selected_transports.push(hybrid);
         }
 
-        futures::stream::select_all(selected_transports).boxed()
+        self.merge_discovery_streams(selected_transports, lifecycle)
     }
 }
 
@@ -458,7 +467,41 @@ where
     })
 }
 
+/// Completes the request if every selected credential transport stops without
+/// producing a terminal event.
+fn discovery_state_stream<S>(
+    mut inner: S,
+    ctx: Arc<Mutex<Option<RequestContext>>>,
+    lifecycle: RequestLifecycle,
+) -> Pin<Box<dyn Stream<Item = DeviceStateUpdate> + Send + 'static>>
+where
+    S: Stream<Item = DeviceStateUpdate> + Unpin + Send + 'static,
+{
+    Box::pin(async_stream::stream! {
+        loop {
+            match lifecycle.cancellation.run_until_cancelled(inner.next()).await {
+                None => break,
+                Some(Some(state)) => yield state,
+                Some(None) => {
+                    if lifecycle.cancellation.is_cancelled() {
+                        break;
+                    }
+
+                    let error = CredentialServiceError::Internal(
+                        "All credential transports ended without a terminal event.".to_string(),
+                    );
+                    if complete_request(&ctx, &lifecycle, Err(error.clone())) {
+                        yield DeviceStateUpdate::Failed(error);
+                    }
+                    break;
+                }
+            }
+        }
+    })
+}
+
 pub enum DeviceStateUpdate {
+    Failed(CredentialServiceError),
     Hybrid(HybridState),
     Nfc(NfcState),
     Usb(UsbState),
@@ -467,6 +510,15 @@ pub enum DeviceStateUpdate {
 impl From<DeviceStateUpdate> for BackgroundEvent {
     fn from(value: DeviceStateUpdate) -> Self {
         match value {
+            DeviceStateUpdate::Failed(error) => match error {
+                CredentialServiceError::AuthenticatorError => BackgroundEvent::ErrorAuthenticator,
+                CredentialServiceError::NoCredentials => BackgroundEvent::ErrorNoCredentials,
+                CredentialServiceError::CredentialExcluded => {
+                    BackgroundEvent::ErrorCredentialExcluded
+                }
+                CredentialServiceError::PinAttemptsExhausted => BackgroundEvent::ErrorAuthenticator,
+                CredentialServiceError::Internal(_) => BackgroundEvent::ErrorInternal,
+            },
             DeviceStateUpdate::Hybrid(state) => (&state).into(),
             DeviceStateUpdate::Nfc(state) => (&state).into(),
             DeviceStateUpdate::Usb(state) => (&state).into(),
@@ -1151,6 +1203,224 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_discovery_continues_when_one_transport_ends_unexpectedly() {
+        let request = create_test_request().await;
+        let (response_channel, response_rx) = oneshot::channel();
+        let cancellation = CancellationToken::new();
+        let request_id = 7;
+        let request_marker = Arc::new(RequestMarker);
+        let ctx = Arc::new(Mutex::new(Some(RequestContext {
+            request,
+            response_channel,
+            request_id,
+            request_marker: request_marker.clone(),
+            cancellation: cancellation.clone(),
+        })));
+        let lifecycle = RequestLifecycle {
+            request_id,
+            request_marker,
+            cancellation: cancellation.clone(),
+        };
+        let hybrid_stream = credential_state_stream(
+            futures::stream::empty::<HybridEvent>(),
+            ctx.clone(),
+            lifecycle.clone(),
+        )
+        .map(DeviceStateUpdate::from)
+        .boxed();
+        let usb_stream = credential_state_stream(
+            futures::stream::iter([
+                UsbEvent {
+                    state: UsbStateInternal::Waiting,
+                },
+                UsbEvent {
+                    state: UsbStateInternal::Completed(create_test_credential_response()),
+                },
+            ]),
+            ctx.clone(),
+            lifecycle.clone(),
+        )
+        .map(DeviceStateUpdate::from)
+        .boxed();
+        let mut stream = discovery_state_stream(
+            futures::stream::select_all(vec![hybrid_stream, usb_stream]),
+            ctx,
+            lifecycle,
+        );
+
+        assert!(matches!(
+            stream.next().await,
+            Some(DeviceStateUpdate::Usb(UsbState::Waiting))
+        ));
+        assert!(!cancellation.is_cancelled());
+        assert!(matches!(
+            stream.next().await,
+            Some(DeviceStateUpdate::Usb(UsbState::Completed))
+        ));
+
+        let result = response_rx.await.expect("request result should be sent");
+        assert!(result.is_ok());
+        assert!(cancellation.is_cancelled());
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_discovery_fails_when_all_transports_end_unexpectedly() {
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
+        let request = create_test_request().await;
+        let (response_channel, response_rx) = oneshot::channel();
+        let (_request_id, cancellation) = service
+            .init_request(&request, response_channel)
+            .await
+            .unwrap();
+        let lifecycle = service.current_request().unwrap().1;
+        let usb_stream = futures::stream::iter([DeviceStateUpdate::Usb(UsbState::Waiting)]).boxed();
+        let hybrid_stream = futures::stream::empty::<DeviceStateUpdate>().boxed();
+        let mut stream =
+            service.merge_discovery_streams(vec![usb_stream, hybrid_stream], lifecycle);
+
+        assert!(matches!(
+            stream.next().await,
+            Some(DeviceStateUpdate::Usb(UsbState::Waiting))
+        ));
+
+        let state = stream
+            .next()
+            .await
+            .expect("exhausting all transports should emit a failure state");
+        assert!(matches!(
+            &state,
+            DeviceStateUpdate::Failed(CredentialServiceError::Internal(message))
+                if message == "All credential transports ended without a terminal event."
+        ));
+        assert_eq!(BackgroundEvent::from(state), BackgroundEvent::ErrorInternal);
+
+        let result = response_rx.await.expect("request result should be sent");
+        assert!(matches!(
+            result,
+            Err(CredentialServiceError::Internal(message))
+                if message == "All credential transports ended without a terminal event."
+        ));
+        assert!(cancellation.is_cancelled());
+        assert!(service.ctx.lock().unwrap().is_none());
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cancelling_pending_discovery_does_not_report_transport_exhaustion() {
+        let (usb_handler, usb_controller) = ScriptedTransport::<UsbStateInternal>::new();
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, usb_handler);
+        let request = create_test_request().await;
+        let (response_channel, response_rx) = oneshot::channel();
+        let (request_id, cancellation) = service
+            .init_request(&request, response_channel)
+            .await
+            .unwrap();
+        let usb_stream = service
+            .get_usb_credential()
+            .await
+            .map(DeviceStateUpdate::from)
+            .boxed();
+        let lifecycle = service.current_request().unwrap().1;
+        let mut stream = service.merge_discovery_streams(vec![usb_stream], lifecycle);
+
+        usb_controller.emit(UsbStateInternal::Waiting);
+        assert!(matches!(
+            stream.next().await,
+            Some(DeviceStateUpdate::Usb(UsbState::Waiting))
+        ));
+
+        let waiting_task = tokio::spawn(async move { stream.next().await });
+        tokio::task::yield_now().await;
+        service.cancel_request(request_id).await;
+
+        let event = tokio::time::timeout(Duration::from_secs(1), waiting_task)
+            .await
+            .expect("cancellation should wake the aggregate discovery stream")
+            .expect("discovery task should not panic");
+        assert!(event.is_none());
+        assert!(cancellation.is_cancelled());
+        assert!(usb_controller.was_cancelled());
+
+        let result = response_rx.await.expect("request result should be sent");
+        assert!(matches!(
+            result,
+            Err(CredentialServiceError::Internal(message))
+                if message == format!("Cancelled request {request_id}.")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_concurrent_terminal_events_emit_only_one_terminal_state() {
+        let request = create_test_request().await;
+        let (response_channel, response_rx) = oneshot::channel();
+        let cancellation = CancellationToken::new();
+        let request_id = 11;
+        let request_marker = Arc::new(RequestMarker);
+        let ctx = Arc::new(Mutex::new(Some(RequestContext {
+            request,
+            response_channel,
+            request_id,
+            request_marker: request_marker.clone(),
+            cancellation: cancellation.clone(),
+        })));
+        let lifecycle = RequestLifecycle {
+            request_id,
+            request_marker,
+            cancellation: cancellation.clone(),
+        };
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+
+        let make_discovery = || {
+            let barrier = barrier.clone();
+            let usb_events = futures::stream::once(async move {
+                barrier.wait().await;
+                UsbEvent {
+                    state: UsbStateInternal::Completed(create_test_credential_response()),
+                }
+            })
+            .boxed();
+            let usb_stream = credential_state_stream(usb_events, ctx.clone(), lifecycle.clone())
+                .map(DeviceStateUpdate::from)
+                .boxed();
+            discovery_state_stream(
+                futures::stream::select_all(vec![usb_stream]),
+                ctx.clone(),
+                lifecycle.clone(),
+            )
+        };
+        let mut first_discovery = make_discovery();
+        let mut second_discovery = make_discovery();
+        let first = tokio::spawn(async move { first_discovery.next().await });
+        let second = tokio::spawn(async move { second_discovery.next().await });
+
+        barrier.wait().await;
+        let (first, second) = tokio::join!(first, second);
+        let events = [
+            first.expect("first discovery task should not panic"),
+            second.expect("second discovery task should not panic"),
+        ];
+        assert_eq!(
+            events
+                .into_iter()
+                .filter(|event| {
+                    matches!(event, Some(DeviceStateUpdate::Usb(UsbState::Completed)))
+                })
+                .count(),
+            1,
+            "only the winning terminal event should be emitted"
+        );
+        assert!(cancellation.is_cancelled());
+        assert!(ctx.lock().unwrap().is_none());
+        assert!(
+            response_rx
+                .await
+                .expect("request result should be sent")
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
     async fn test_lifecycle_stream_cannot_complete_a_newer_request() {
         let request = create_test_request().await;
         let (response_channel, mut response_rx) = oneshot::channel();
@@ -1188,6 +1458,48 @@ mod tests {
             response_rx.try_recv(),
             Err(oneshot::error::TryRecvError::Empty)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_stale_discovery_exhaustion_cannot_complete_a_newer_request() {
+        let service = CredentialService::new(EmptyTransport, EmptyTransport, EmptyTransport);
+        let request = create_test_request().await;
+        let (stale_response_tx, stale_response_rx) = oneshot::channel();
+        let (stale_request_id, _stale_cancellation) = service
+            .init_request(&request, stale_response_tx)
+            .await
+            .unwrap();
+        let stale_lifecycle = service.current_request().unwrap().1;
+
+        service.cancel_request(stale_request_id).await;
+        assert!(stale_response_rx.await.unwrap().is_err());
+
+        let (current_response_tx, mut current_response_rx) = oneshot::channel();
+        let (current_request_id, current_cancellation) = service
+            .init_request(&request, current_response_tx)
+            .await
+            .unwrap();
+        let stale_transport = futures::stream::empty::<DeviceStateUpdate>().boxed();
+        let mut stale_discovery =
+            service.merge_discovery_streams(vec![stale_transport], stale_lifecycle);
+
+        assert!(stale_discovery.next().await.is_none());
+        assert!(!current_cancellation.is_cancelled());
+        assert_eq!(
+            service
+                .ctx
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|ctx| ctx.request_id),
+            Some(current_request_id)
+        );
+        assert!(matches!(
+            current_response_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+
+        service.cancel_request(current_request_id).await;
     }
 
     #[tokio::test]

--- a/credentialsd/src/credential_service/mod.rs
+++ b/credentialsd/src/credential_service/mod.rs
@@ -66,10 +66,14 @@ fn persistent_token_store() -> Arc<dyn PersistentTokenStore> {
 }
 
 #[derive(Debug)]
+struct RequestMarker;
+
+#[derive(Debug)]
 struct RequestContext {
     request: CredentialRequest,
     response_channel: oneshot::Sender<Result<CredentialResponse, CredentialServiceError>>,
     request_id: RequestId,
+    request_marker: Arc<RequestMarker>,
     cancellation: CancellationToken,
 }
 
@@ -132,6 +136,8 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
         if let Some(RequestContext {
             ref request,
             ref cancellation,
+            ref request_marker,
+            request_id,
             ..
         }) = *guard
         {
@@ -141,7 +147,13 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
                 .unwrap()
                 .start(request, cancellation.clone());
             let ctx = self.ctx.clone();
-            credential_state_stream(stream, ctx, cancellation.clone())
+            credential_state_stream(
+                stream,
+                ctx,
+                request_id,
+                request_marker.clone(),
+                cancellation.clone(),
+            )
         } else {
             tracing::error!(
                 "Attempted to start hybrid credential flow, but no request context was found."
@@ -155,6 +167,8 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
         if let Some(RequestContext {
             ref request,
             ref cancellation,
+            ref request_marker,
+            request_id,
             ..
         }) = *guard
         {
@@ -164,7 +178,13 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
                 .unwrap()
                 .start(request, cancellation.clone());
             let ctx = self.ctx.clone();
-            credential_state_stream(stream, ctx, cancellation.clone())
+            credential_state_stream(
+                stream,
+                ctx,
+                request_id,
+                request_marker.clone(),
+                cancellation.clone(),
+            )
         } else {
             tracing::error!(
                 "Attempted to start usb credential flow, but no request context was found."
@@ -178,6 +198,8 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
         if let Some(RequestContext {
             ref request,
             ref cancellation,
+            ref request_marker,
+            request_id,
             ..
         }) = *guard
         {
@@ -187,7 +209,13 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send>
                 .unwrap()
                 .start(request, cancellation.clone());
             let ctx = self.ctx.clone();
-            credential_state_stream(stream, ctx, cancellation.clone())
+            credential_state_stream(
+                stream,
+                ctx,
+                request_id,
+                request_marker.clone(),
+                cancellation.clone(),
+            )
         } else {
             tracing::error!(
                 "Attempted to start nfc credential flow, but no request context was found."
@@ -221,6 +249,7 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send> Manage
                 request: request.clone(),
                 response_channel: tx,
                 request_id,
+                request_marker: Arc::new(RequestMarker),
                 cancellation: cancellation.clone(),
             };
             _ = cred_request.insert(ctx);
@@ -306,6 +335,7 @@ impl<H: HybridHandler + Send, N: NfcHandler + Send, U: UsbHandler + Send> Manage
                 .boxed();
             selected_transports.push(hybrid);
         }
+
         futures::stream::select_all(selected_transports).boxed()
     }
 }
@@ -384,6 +414,8 @@ impl TransportEvent for NfcEvent {
 fn credential_state_stream<S, E>(
     mut inner: S,
     ctx: Arc<Mutex<Option<RequestContext>>>,
+    request_id: RequestId,
+    request_marker: Arc<RequestMarker>,
     cancellation_token: CancellationToken,
 ) -> Pin<Box<dyn Stream<Item = E::PublicState> + Send + 'static>>
 where
@@ -407,7 +439,9 @@ where
 
             let (state, result) = event.into_state_and_result();
             if let Some(result) = result {
-                complete_request(&ctx, result);
+                if !complete_request(&ctx, request_id, &request_marker, result) {
+                    break;
+                }
                 yield state;
                 break;
             }
@@ -453,17 +487,25 @@ impl From<UsbState> for DeviceStateUpdate {
 
 fn complete_request(
     ctx: &Mutex<Option<RequestContext>>,
+    request_id: RequestId,
+    request_marker: &Arc<RequestMarker>,
     response: Result<CredentialResponse, CredentialServiceError>,
-) {
-    match ctx.lock().unwrap().take() {
-        Some(ctx) => {
-            ctx.cancellation.cancel();
-            ctx.send_response(response);
-        }
-        _ => {
-            tracing::error!("Tried to consume context to respond to caller, but none was found.")
-        }
-    }
+) -> bool {
+    let request_ctx = ctx.lock().unwrap().take_if(|request_ctx| {
+        request_ctx.request_id == request_id
+            && Arc::ptr_eq(&request_ctx.request_marker, request_marker)
+    });
+    let Some(request_ctx) = request_ctx else {
+        tracing::debug!(
+            request_id,
+            "Ignoring terminal event for a request that is no longer active."
+        );
+        return false;
+    };
+
+    request_ctx.cancellation.cancel();
+    request_ctx.send_response(response);
+    true
 }
 
 #[derive(Debug, Clone)]
@@ -963,15 +1005,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_scripted_hybrid_transport_propagates_successful_response() {
+        let (hybrid_handler, hybrid_controller) = ScriptedTransport::<HybridStateInternal>::new();
+        let service = CredentialService::new(hybrid_handler, EmptyTransport, EmptyTransport);
+        let request = create_test_request().await;
+        let (tx, rx) = oneshot::channel();
+
+        let (_request_id, cancellation_token) = service.init_request(&request, tx).await.unwrap();
+        let mut hybrid_stream = service.get_hybrid_credential().await;
+
+        hybrid_controller.emit(HybridStateInternal::Connecting);
+        assert!(matches!(
+            hybrid_stream.next().await,
+            Some(HybridState::Connecting)
+        ));
+
+        hybrid_controller.complete(create_test_credential_response());
+        assert!(matches!(
+            hybrid_stream.next().await,
+            Some(HybridState::Completed)
+        ));
+        assert!(cancellation_token.is_cancelled());
+
+        let result = rx.await.expect("request result should be sent");
+        let Ok(CredentialResponse::GetPublicKeyCredentialResponse(response)) = result else {
+            panic!("Hybrid completion should propagate the credential response");
+        };
+        assert_eq!(response.attachment_modality, "cross-platform");
+    }
+
+    #[tokio::test]
     async fn test_lifecycle_stream_discards_event_after_cancellation() {
         let request = create_test_request().await;
         let (response_channel, _response_rx) = oneshot::channel();
         let cancellation = CancellationToken::new();
+        let request_marker = Arc::new(RequestMarker);
         cancellation.cancel();
         let ctx = Arc::new(Mutex::new(Some(RequestContext {
             request,
             response_channel,
             request_id: 1,
+            request_marker: request_marker.clone(),
             cancellation: cancellation.clone(),
         })));
         let mut stream = credential_state_stream(
@@ -979,6 +1053,8 @@ mod tests {
                 state: UsbStateInternal::Waiting,
             }]),
             ctx.clone(),
+            1,
+            request_marker,
             cancellation,
         );
 
@@ -994,10 +1070,12 @@ mod tests {
         let request = create_test_request().await;
         let (response_channel, _response_rx) = oneshot::channel();
         let cancellation = CancellationToken::new();
+        let request_marker = Arc::new(RequestMarker);
         let ctx = Arc::new(Mutex::new(Some(RequestContext {
             request,
             response_channel,
             request_id: 1,
+            request_marker: request_marker.clone(),
             cancellation: cancellation.clone(),
         })));
         let (polled_tx, polled_rx) = oneshot::channel();
@@ -1008,7 +1086,13 @@ mod tests {
             }
             Poll::<Option<UsbEvent>>::Pending
         });
-        let mut stream = credential_state_stream(pending_inner, ctx.clone(), cancellation.clone());
+        let mut stream = credential_state_stream(
+            pending_inner,
+            ctx.clone(),
+            1,
+            request_marker,
+            cancellation.clone(),
+        );
 
         let waiting_task = tokio::spawn(async move { stream.next().await });
         polled_rx.await.expect("inner stream should be polled");
@@ -1023,6 +1107,44 @@ mod tests {
             ctx.lock().unwrap().is_some(),
             "cancelling a pending stream must not complete the active request"
         );
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_stream_cannot_complete_a_newer_request() {
+        let request = create_test_request().await;
+        let (response_channel, mut response_rx) = oneshot::channel();
+        let current_cancellation = CancellationToken::new();
+        let current_request_marker = Arc::new(RequestMarker);
+        let ctx = Arc::new(Mutex::new(Some(RequestContext {
+            request,
+            response_channel,
+            request_id: 1,
+            request_marker: current_request_marker,
+            cancellation: current_cancellation.clone(),
+        })));
+        let stale_cancellation = CancellationToken::new();
+        let stale_request_marker = Arc::new(RequestMarker);
+        let mut stale_stream = credential_state_stream(
+            futures::stream::iter([UsbEvent {
+                state: UsbStateInternal::Completed(create_test_credential_response()),
+            }]),
+            ctx.clone(),
+            1,
+            stale_request_marker,
+            stale_cancellation.clone(),
+        );
+
+        assert!(stale_stream.next().await.is_none());
+        assert!(!stale_cancellation.is_cancelled());
+        assert!(!current_cancellation.is_cancelled());
+        assert_eq!(
+            ctx.lock().unwrap().as_ref().map(|ctx| ctx.request_id),
+            Some(1)
+        );
+        assert!(matches!(
+            response_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
     }
 
     #[tokio::test]

--- a/credentialsd/src/credential_service/nfc.rs
+++ b/credentialsd/src/credential_service/nfc.rs
@@ -23,7 +23,7 @@ use crate::model::{CredentialRequest, GetAssertionResponseInternal};
 use super::{AuthenticatorResponse, CredentialResponse};
 
 pub(crate) trait NfcHandler {
-    #[expect(unused)]
+    #[cfg_attr(not(test), expect(unused))]
     fn start(
         &self,
         request: &CredentialRequest,
@@ -364,13 +364,13 @@ impl NfcHandler for InProcessNfcHandler {
 
 // this exists to prevent making NfcStateInternal type public to the whole crate.
 /// A message between NFC handler and credential service
-#[expect(unused)]
+#[cfg_attr(not(test), expect(unused))]
 pub struct NfcEvent {
     pub(super) state: NfcStateInternal,
 }
 
 /// Used to share internal state between handler and credential service
-#[expect(unused)]
+#[cfg_attr(not(test), expect(unused))]
 #[derive(Clone, Debug, Default)]
 pub(super) enum NfcStateInternal {
     /// Not polling for FIDO NFC device.

--- a/credentialsd/src/credential_service/test_support.rs
+++ b/credentialsd/src/credential_service/test_support.rs
@@ -1,0 +1,212 @@
+//! Scripted credential transports used by unit tests.
+
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use futures_lite::Stream;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    CredentialRequest, CredentialResponse, CredentialServiceError,
+    hybrid::{HybridEvent, HybridHandler, HybridStateInternal},
+    nfc::{NfcEvent, NfcHandler, NfcStateInternal},
+    usb::{UsbEvent, UsbHandler, UsbStateInternal},
+};
+
+/// A transport that never emits an event.
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct EmptyTransport;
+
+impl UsbHandler for EmptyTransport {
+    fn start(
+        &self,
+        _request: &CredentialRequest,
+        _cancellation: CancellationToken,
+    ) -> impl Stream<Item = UsbEvent> + Send + Sized + Unpin + 'static {
+        futures::stream::empty()
+    }
+}
+
+impl HybridHandler for EmptyTransport {
+    fn start(
+        &self,
+        _request: &CredentialRequest,
+        _cancellation: CancellationToken,
+    ) -> impl Stream<Item = HybridEvent> + Send + Sized + Unpin + 'static {
+        futures::stream::empty()
+    }
+}
+
+impl NfcHandler for EmptyTransport {
+    fn start(
+        &self,
+        _request: &CredentialRequest,
+        _cancellation: CancellationToken,
+    ) -> impl Stream<Item = NfcEvent> + Send + Sized + Unpin + 'static {
+        futures::stream::empty()
+    }
+}
+
+/// Test-side control handle for a [`ScriptedTransport`].
+#[derive(Clone)]
+pub(super) struct ScriptedTransportController<T> {
+    tx: UnboundedSender<T>,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl<T> ScriptedTransportController<T> {
+    /// Emit the next internal transport state.
+    pub(super) fn emit(&self, state: T) {
+        assert!(
+            self.tx.send(state).is_ok(),
+            "scripted transport stream has already stopped"
+        );
+    }
+
+    /// Whether the scripted transport observed its cancellation token.
+    pub(super) fn was_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+}
+
+pub(super) trait ScriptedState {
+    fn completed(response: CredentialResponse) -> Self;
+    fn failed(error: CredentialServiceError) -> Self;
+}
+
+impl ScriptedState for UsbStateInternal {
+    fn completed(response: CredentialResponse) -> Self {
+        Self::Completed(response)
+    }
+
+    fn failed(error: CredentialServiceError) -> Self {
+        Self::Failed(error)
+    }
+}
+
+impl ScriptedState for HybridStateInternal {
+    fn completed(response: CredentialResponse) -> Self {
+        Self::Completed(response)
+    }
+
+    fn failed(error: CredentialServiceError) -> Self {
+        Self::Failed(error)
+    }
+}
+
+impl ScriptedState for NfcStateInternal {
+    fn completed(response: CredentialResponse) -> Self {
+        Self::Completed(response)
+    }
+
+    fn failed(error: CredentialServiceError) -> Self {
+        Self::Failed(error)
+    }
+}
+
+impl<T: ScriptedState> ScriptedTransportController<T> {
+    /// Complete the active credential request successfully.
+    pub(super) fn complete(&self, response: CredentialResponse) {
+        self.emit(T::completed(response));
+    }
+
+    /// Fail the active credential request.
+    pub(super) fn fail(&self, error: CredentialServiceError) {
+        self.emit(T::failed(error));
+    }
+}
+
+/// A push-based mock transport with deterministic cancellation tracking.
+pub(super) struct ScriptedTransport<T> {
+    rx: Mutex<Option<UnboundedReceiver<T>>>,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl<T> std::fmt::Debug for ScriptedTransport<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScriptedTransport")
+            .field("cancelled", &self.cancelled.load(Ordering::SeqCst))
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> ScriptedTransport<T> {
+    pub(super) fn new() -> (Self, ScriptedTransportController<T>) {
+        let (tx, rx) = unbounded_channel();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        (
+            Self {
+                rx: Mutex::new(Some(rx)),
+                cancelled: cancelled.clone(),
+            },
+            ScriptedTransportController { tx, cancelled },
+        )
+    }
+
+    /// Build a stream that prioritizes cancellation over queued events.
+    fn start_with<E>(
+        &self,
+        cancellation: CancellationToken,
+        wrap: impl Fn(T) -> E + Send + 'static,
+    ) -> impl Stream<Item = E> + Send + Unpin + 'static
+    where
+        T: Send + 'static,
+        E: Send + 'static,
+    {
+        let mut rx = self
+            .rx
+            .lock()
+            .unwrap()
+            .take()
+            .expect("ScriptedTransport can only be started once");
+        let cancelled = self.cancelled.clone();
+        Box::pin(async_stream::stream! {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => {
+                        cancelled.store(true, Ordering::SeqCst);
+                        break;
+                    }
+                    maybe = rx.recv() => match maybe {
+                        Some(state) => yield wrap(state),
+                        None => break,
+                    }
+                }
+            }
+        })
+    }
+}
+
+impl UsbHandler for ScriptedTransport<UsbStateInternal> {
+    fn start(
+        &self,
+        _request: &CredentialRequest,
+        cancellation: CancellationToken,
+    ) -> impl Stream<Item = UsbEvent> + Send + Sized + Unpin + 'static {
+        self.start_with(cancellation, |state| UsbEvent { state })
+    }
+}
+
+impl HybridHandler for ScriptedTransport<HybridStateInternal> {
+    fn start(
+        &self,
+        _request: &CredentialRequest,
+        cancellation: CancellationToken,
+    ) -> impl Stream<Item = HybridEvent> + Send + Sized + Unpin + 'static {
+        self.start_with(cancellation, |state| HybridEvent { state })
+    }
+}
+
+impl NfcHandler for ScriptedTransport<NfcStateInternal> {
+    fn start(
+        &self,
+        _request: &CredentialRequest,
+        cancellation: CancellationToken,
+    ) -> impl Stream<Item = NfcEvent> + Send + Sized + Unpin + 'static {
+        self.start_with(cancellation, |state| NfcEvent { state })
+    }
+}


### PR DESCRIPTION
> **Draft — depends on #225, which depends on #224.** Review the isolated changes in [the fork PR](https://github.com/Preovaleo/credentialsd/pull/3/files).

## Split and stacked review

Original PR: [linux-credentials/credentialsd#220](https://github.com/linux-credentials/credentialsd/pull/220).

The replacement is split into four parts. Parts 1 → 2 → 3 form [native GitHub stack #4 on the fork](https://github.com/Preovaleo/credentialsd/pull/2); part 4 is independent.

| Part | Upstream integration PR (targets `main`) | Focused stacked review on the fork |
| --- | --- | --- |
| 1 — Shared transport lifecycle | [#224](https://github.com/linux-credentials/credentialsd/pull/224) | [Preovaleo/credentialsd#2](https://github.com/Preovaleo/credentialsd/pull/2) — `/1` → `main` |
| 2 — Cancellation and request ownership | [#225](https://github.com/linux-credentials/credentialsd/pull/225) | [Preovaleo/credentialsd#1](https://github.com/Preovaleo/credentialsd/pull/1) — `/2` → `/1` |
| 3 — Silent transport exhaustion | [#226](https://github.com/linux-credentials/credentialsd/pull/226) | [Preovaleo/credentialsd#3](https://github.com/Preovaleo/credentialsd/pull/3) — `/3` → `/2` |
| 4 — Discovery concurrency bound | [#227](https://github.com/linux-credentials/credentialsd/pull/227) | Independent; review directly upstream |

Review and integrate parts 1 → 2 → 3 in order. Part 4 can be reviewed and merged independently.

GitHub does not support native stacks across forks. Use **Files changed on the fork PRs** for incremental review of each layer. The upstream PRs target `main`; #225 and #226 include earlier layers until their dependencies land and the branches are rebased. Integration into the main project happens through the upstream PRs; merging the fork stack only updates the fork.

Hello 👋,

## Summary

This PR extracts silent transport exhaustion handling from linux-credentials/credentialsd#220. It builds on the request lifecycle and ownership guarantees introduced in parts 1 and 2.

Previously, every selected transport could end without producing a terminal result. The merged discovery stream would then end while the credential request remained active, leaving its caller waiting indefinitely.

This PR:

- wraps the merged transport streams with aggregate discovery lifecycle handling;
- completes the originating request with an error if every selected transport ends without a terminal result;
- introduces a transport-independent failure update and maps it to the UI background error event;
- preserves discovery while another selected transport remains active;
- ignores exhaustion from cancelled or stale discovery streams;
- adds regression coverage and updates the architecture documentation and changelog.

## Result

A transport ending without a result does not immediately fail discovery. Other selected transports can continue and complete the request.

If all selected transports end without a terminal event, the daemon completes the request with an internal error and emits the corresponding failure update.

Explicit cancellation retains its cancellation outcome. Exhaustion from an older discovery stream cannot consume or fail a newer request. A valid terminal result continues to complete the request and cancel competing transports.

## Scope and dependencies

This is part 3 of the split. It depends on [part 2](https://github.com/linux-credentials/credentialsd/pull/225), which depends on [part 1](https://github.com/linux-credentials/credentialsd/pull/224).

The focused review base is `perso/generic_transport-split/2`. Review and integrate the parts in the order 1 → 2 → 3. Part 4 is independent.

Authenticator enumeration, dynamic source-list updates, and retry policy remain separate concerns tracked by linux-credentials/credentialsd#32 and linux-credentials/credentialsd#206.

## Diff composition

| Scope | Test code | Daemon code | Moved/reused text (included) |
| --- | ---: | ---: | ---: |
| **This layer, relative to part 2** | ≈82% | ≈18% | ≈0% |

## Commit sequence and rationale

The commit order follows the dependencies between these changes:

1. **[daemon: Fail discovery when all transports exit silently](https://github.com/linux-credentials/credentialsd/commit/f17369c321d1559038669a6802a4e2721f124d3a)**

   A transport reaching EOF is not enough to conclude that the request cannot succeed: another selected transport may still produce a credential. The failure decision therefore belongs around the merged discovery stream. This is why the change adds aggregate lifecycle handling after parts 1 and 2, using their request snapshot to scope completion and distinguish exhaustion from cancellation.

   No individual transport supplies the error in this case, so `DeviceStateUpdate::Failed` represents the aggregate outcome and maps it to the UI error event. Resolving the caller's response and exposing that failure to the UI are included together. The accompanying tests establish the boundary of the decision: partial exhaustion leaves discovery running, global exhaustion ends it, and cancelled or stale discovery cannot fail a replacement request. The concurrent-terminal test also exercises how the new wrapper composes with the single accepted completion from part 2.

2. **[docs: Describe silent transport exhaustion](https://github.com/linux-credentials/credentialsd/commit/2d72fc0cdaa61590683b13a8135c4a3d1e050176)**

   The architecture and changelog record the new termination rule once the aggregate behavior is in place. The rule applies to exhaustion of the selected streams; decisions about selecting new authenticators or starting another discovery attempt remain with the discovery policy.

## Testing

Validation performed at the branch tip during the split:

- `cargo test -p credentialsd --bin credentialsd` — 38 tests passed
- `cargo clippy -p credentialsd --bin credentialsd -- -Dwarnings` — passed
- `cargo fmt --all --check` — passed
- `git diff --check` — passed

The tests check response delivery, public failure events, cancellation, and protection of a newer request from stale discovery exhaustion.
