### PR TITLE
daemon: Bound concurrent credential discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 
+- daemon: Prevent concurrent discovery streams for the same credential request.
 - ui: Remove process ID from credential prompt.
 
 # 0.3.0 [2026-08-27]

--- a/credentialsd/src/dbus/flow_control.rs
+++ b/credentialsd/src/dbus/flow_control.rs
@@ -18,7 +18,7 @@ use credentialsd_common::{
 use futures_lite::{Stream, StreamExt};
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::oneshot;
-use tokio::sync::{Mutex as AsyncMutex, mpsc::Sender};
+use tokio::sync::{Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore, mpsc::Sender};
 use tokio::task::AbortHandle;
 use zbus::connection::Connection;
 use zbus::zvariant::OwnedObjectPath;
@@ -146,6 +146,7 @@ async fn handle<M: ManageDevice + Debug + Send + Sync + 'static, UC: UiControlle
         let client_pin_tx: Arc<Mutex<Option<Sender<String>>>> = Arc::new(Mutex::new(None));
         let set_pin_tx: Arc<Mutex<Option<Sender<String>>>> = Arc::new(Mutex::new(None));
         let cred_selector_tx = Arc::new(Mutex::new(None));
+        let discovery_gate = Arc::new(Semaphore::new(1));
 
         let wait_for_ui_request_fut = async {
             loop {
@@ -155,6 +156,13 @@ async fn handle<M: ManageDevice + Debug + Send + Sync + 'static, UC: UiControlle
                 };
                 match ui_request {
                     UserInteractedEvent::DiscoveryRequested => {
+                        let Some(discovery_permit) = claim_discovery(&discovery_gate) else {
+                            tracing::debug!(
+                                %request_id,
+                                "Ignoring discovery request while discovery is already active."
+                            );
+                            continue;
+                        };
                         let client_pin_tx = client_pin_tx.clone();
                         let set_pin_tx = set_pin_tx.clone();
                         let cred_selector_tx = cred_selector_tx.clone();
@@ -203,7 +211,7 @@ async fn handle<M: ManageDevice + Debug + Send + Sync + 'static, UC: UiControlle
                                     device_update.into()
                                 });
                         let flow = flow.clone();
-                        forward_background_event_stream(flow, stream);
+                        forward_background_event_stream(flow, stream, discovery_permit);
                     }
                     UserInteractedEvent::ClientPinEntered(pin_fd) => {
                         let pin_fd = OwnedFd::from(pin_fd);
@@ -295,9 +303,20 @@ async fn handle<M: ManageDevice + Debug + Send + Sync + 'static, UC: UiControlle
         .expect("Credential service not to drop request channel before responding.")
 }
 
+/// Claims the single active discovery slot for a credential request.
+///
+/// The semaphore must be scoped to one request, and the returned permit must be
+/// held until its discovery stream ends. D-Bus sender and session validation is
+/// handled before this point; this additional bound protects the daemon from a
+/// faulty trusted UI without preventing a later discovery attempt.
+fn claim_discovery(discovery_gate: &Arc<Semaphore>) -> Option<OwnedSemaphorePermit> {
+    discovery_gate.clone().try_acquire_owned().ok()
+}
+
 fn forward_background_event_stream(
     flow: Ceremony,
     mut stream: impl Stream<Item = BackgroundEvent> + Send + Unpin + 'static,
+    _discovery_permit: OwnedSemaphorePermit,
 ) {
     tokio::spawn(async move {
         while let Some(event) = stream.next().await {
@@ -309,6 +328,29 @@ fn forward_background_event_stream(
         }
         tracing::debug!("Background event stream ended");
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovery_can_restart_after_the_active_stream_releases_its_claim() {
+        let discovery_gate = Arc::new(Semaphore::new(1));
+
+        let active_discovery =
+            claim_discovery(&discovery_gate).expect("first discovery should claim the slot");
+        assert!(
+            claim_discovery(&discovery_gate).is_none(),
+            "a concurrent discovery must not claim the same request"
+        );
+
+        drop(active_discovery);
+        assert!(
+            claim_discovery(&discovery_gate).is_some(),
+            "ending the active discovery must allow a later attempt"
+        );
+    }
 }
 
 /// Coordinates between user and various devices connected to the machine to

--- a/credentialsd/src/dbus/flow_control.rs
+++ b/credentialsd/src/dbus/flow_control.rs
@@ -24,6 +24,7 @@ use zbus::connection::Connection;
 use zbus::zvariant::OwnedObjectPath;
 
 use crate::dbus::UiControlServiceClient;
+use crate::gateway::WebAuthnError;
 use crate::{
     credential_service::UsbState,
     dbus::ui_control::UiController,
@@ -33,7 +34,6 @@ use crate::{
     credential_service::{DeviceStateUpdate, ManageDevice, nfc::NfcState},
     model::ClientDetails,
 };
-use crate::{dbus::ui_control::Ceremony, gateway::WebAuthnError};
 
 pub struct UiRequestContext {
     request: CredentialRequest,
@@ -211,7 +211,14 @@ async fn handle<M: ManageDevice + Debug + Send + Sync + 'static, UC: UiControlle
                                     device_update.into()
                                 });
                         let flow = flow.clone();
-                        forward_background_event_stream(flow, stream, discovery_permit);
+                        forward_background_event_stream(
+                            move |event| {
+                                let flow = flow.clone();
+                                async move { flow.send_state_update(event).await }
+                            },
+                            stream,
+                            discovery_permit,
+                        );
                     }
                     UserInteractedEvent::ClientPinEntered(pin_fd) => {
                         let pin_fd = OwnedFd::from(pin_fd);
@@ -313,14 +320,15 @@ fn claim_discovery(discovery_gate: &Arc<Semaphore>) -> Option<OwnedSemaphorePerm
     discovery_gate.clone().try_acquire_owned().ok()
 }
 
-fn forward_background_event_stream(
-    flow: Ceremony,
+fn forward_background_event_stream<F: Future<Output = Result<(), ()>> + Send>(
+    mut send_state_update: impl FnMut(BackgroundEvent) -> F + Send + 'static,
     mut stream: impl Stream<Item = BackgroundEvent> + Send + Unpin + 'static,
-    _discovery_permit: OwnedSemaphorePermit,
+    discovery_permit: OwnedSemaphorePermit,
 ) {
     tokio::spawn(async move {
+        let _discovery_permit = discovery_permit;
         while let Some(event) = stream.next().await {
-            let send_result = flow.send_state_update(event).await;
+            let send_result = send_state_update(event).await;
             if send_result.is_err() {
                 tracing::error!("Failed to send state update event to backend. Stopping flow");
                 break;
@@ -333,6 +341,40 @@ fn forward_background_event_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn discovery_slot_is_held_until_background_stream_ends() {
+        let discovery_gate = Arc::new(Semaphore::new(1));
+        let permit = claim_discovery(&discovery_gate).unwrap();
+        let (events_tx, mut events_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (polled_tx, polled_rx) = oneshot::channel();
+        let mut polled_tx = Some(polled_tx);
+        let stream = futures::stream::poll_fn(move |cx| {
+            if let Some(tx) = polled_tx.take() {
+                let _ = tx.send(());
+            }
+            events_rx.poll_recv(cx)
+        });
+
+        forward_background_event_stream(|_| async { Ok(()) }, stream, permit);
+        assert!(claim_discovery(&discovery_gate).is_none());
+        tokio::time::timeout(std::time::Duration::from_secs(1), polled_rx)
+            .await
+            .expect("background stream should be polled")
+            .unwrap();
+        assert!(claim_discovery(&discovery_gate).is_none());
+
+        drop(events_tx);
+        let next_permit = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            discovery_gate.clone().acquire_owned(),
+        )
+        .await
+        .expect("ending the stream should release the discovery slot")
+        .unwrap();
+        drop(next_permit);
+        assert!(claim_discovery(&discovery_gate).is_some());
+    }
 
     #[test]
     fn discovery_can_restart_after_the_active_stream_releases_its_claim() {


### PR DESCRIPTION
## Split and stacked review

Original PR: [linux-credentials/credentialsd#220](https://github.com/linux-credentials/credentialsd/pull/220).

The replacement is split into four parts. Parts 1 → 2 → 3 form [native GitHub stack #4 on the fork](https://github.com/Preovaleo/credentialsd/pull/2); part 4 is independent.

| Part | Upstream integration PR (targets `main`) | Focused stacked review on the fork |
| --- | --- | --- |
| 1 — Shared transport lifecycle | [#224](https://github.com/linux-credentials/credentialsd/pull/224) | [Preovaleo/credentialsd#2](https://github.com/Preovaleo/credentialsd/pull/2) — `/1` → `main` |
| 2 — Cancellation and request ownership | [#225](https://github.com/linux-credentials/credentialsd/pull/225) | [Preovaleo/credentialsd#1](https://github.com/Preovaleo/credentialsd/pull/1) — `/2` → `/1` |
| 3 — Silent transport exhaustion | [#226](https://github.com/linux-credentials/credentialsd/pull/226) | [Preovaleo/credentialsd#3](https://github.com/Preovaleo/credentialsd/pull/3) — `/3` → `/2` |
| 4 — Discovery concurrency bound | [#227](https://github.com/linux-credentials/credentialsd/pull/227) | Independent; review directly upstream |

Review and integrate parts 1 → 2 → 3 in order. Part 4 can be reviewed and merged independently.

GitHub does not support native stacks across forks. Use **Files changed on the fork PRs** for incremental review of each layer. The upstream PRs target `main`; #225 and #226 include earlier layers until their dependencies land and the branches are rebased. Integration into the main project happens through the upstream PRs; merging the fork stack only updates the fork.

Hello 👋,

## Summary

This PR extracts the trusted UI discovery concurrency bound from #220 and fixes the lifetime of its discovery permit.

Repeated `DiscoveryRequested` signals could start multiple discovery tasks for the same credential request. Each task could initiate device discovery and forward background events independently.

This PR:

- adds a single discovery slot scoped to each credential request;
- claims the slot before starting discovery;
- ignores additional discovery requests while that slot is occupied;
- keeps the permit inside the spawned background task;
- releases the slot when the task exits, allowing a later discovery attempt;
- adds regression coverage for the actual background stream lifetime;
- updates the changelog.

## Result

Each credential request can have one active discovery stream at a time. The slot remains occupied while the background stream is pending or forwarding events. When the stream ends, or forwarding stops because sending an update fails, the task releases its permit.

A later discovery attempt can claim the slot again while the request remains active.

The permit is explicitly moved into the spawned task. Passing an unused permit to the spawning function would release it when that function returns, making the concurrency bound ineffective.

## Scope and dependencies

This is part 4 of the split. It is based directly on `main` and is independent of the stack starting at #224 and #225; it can be reviewed and merged separately.

The bound applies after the existing D-Bus sender and session validation, protecting the daemon from repeated discovery signals from a faulty trusted UI.

Authenticator enumeration, dynamic source-list updates, and retry policy remain separate concerns tracked by #32 and #206.

## Diff composition

| Scope | Test code | Daemon code | Moved/reused text (included) |
| --- | ---: | ---: | ---: |
| **This PR, relative to `main`** | ≈57% | ≈43% | ≈0% |
| `8054b8c` — Bound concurrent discovery | ≈46% | ≈54% | ≈0% |
| `35415ed` — Hold the permit in the task | ≈61% | ≈39% | ≈0% |

## Commit sequence and rationale

The commit order follows the dependencies between these changes:

1. **[daemon: Bound concurrent credential discovery](https://github.com/linux-credentials/credentialsd/commit/8054b8cc1a4d874bf61288ccb5396cecd1873b27)**

   The lifecycle fixes make completion safer, but repeated UI signals can still launch redundant discovery tasks. The bound belongs at the `DiscoveryRequested` entry point, before starting that work. A request-scoped semaphore expresses one active discovery attempt, and immediate acquisition lets an additional signal be ignored while that attempt is running. Releasing the slot allows a subsequent attempt, so the bound does not impose a one-discovery-per-request policy. This is independent of the transport stream changes in parts 1–3.

2. **[daemon: Hold discovery permit for the background task lifetime](https://github.com/linux-credentials/credentialsd/commit/35415ede5f90195ffe121ae8f4408d9cb61f955e)**

   The first commit passes the permit to the forwarding function but leaves it unused by the spawned future. It is consequently dropped when the function returns, before discovery ends. This commit fixes that ownership by moving the permit into the background task, making the bound last across the forwarding loop and its waits.

   The original test covered acquiring and releasing a semaphore permit, so it could pass despite that integration error. Supplying the event sender as a callback lets the regression test run the actual forwarding function without a D-Bus connection. Holding its stream pending and then closing it demonstrates the lifetime the bound depends on. The changelog accompanies the completed behavior.

## Testing

Validation performed at the branch tip during the split:

- `cargo test -p credentialsd --bin credentialsd` — 27 tests passed
- `cargo clippy -p credentialsd --bin credentialsd -- -Dwarnings` — passed
- `cargo fmt --all --check` — passed
- `git diff --check` — passed

The added tests cover concurrent slot acquisition, retention while the background stream is pending, and release after stream completion. The background-task regression test runs without a live D-Bus service or physical authenticator.
