### PR TITLE
feat: add more app IDs to trusted firefox clients

### DIFF
--- a/credentialsd/src/gateway/mod.rs
+++ b/credentialsd/src/gateway/mod.rs
@@ -297,6 +297,8 @@ fn check_origin_from_app(
     let is_privileged_client = {
         let trusted_clients = [
             "org.mozilla.firefox",
+            "firefox",
+            "firefox-developer-edition",
             "xyz.iinuwa.credentialsd.DemoCredentialsUi",
         ];
         let mut privileged = trusted_clients.contains(&app_id.as_ref());


### PR DESCRIPTION
Distros like Arch don't use `org.mozilla.firefox`